### PR TITLE
[hotfix/OS-793 => QA] Back-office: Décision en SIC > Disparition de commentaire juste après une transition d_état

### DIFF
--- a/views/common/detail_tabs/checklist.py
+++ b/views/common/detail_tabs/checklist.py
@@ -789,7 +789,7 @@ class SicDecisionMixin(CheckListDefaultContextMixin):
                     form_url=resolve_url(
                         f'{self.base_namespace}:save-comment', uuid=self.admission_uuid, tab='decision_sic'
                     ),
-                    prefix='decision_sic__derogation',
+                    prefix='decision_sic',
                 ),
                 'decision_sic__derogation': CommentForm(
                     comment=comment_derogation,


### PR DESCRIPTION
Pull request automatique de hotfix/OS-793 vers QA