### PR TITLE
[hotfix/OS-851 => DEV] osis-mail-template : adapter la configuration de l_éditeur HTML pour supporter correctement le mail d_autorisation SIC

### DIFF
--- a/forms/admission/checklist.py
+++ b/forms/admission/checklist.py
@@ -1092,8 +1092,7 @@ class SicDecisionFinalRefusalForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['body'].widget.attrs['data-config'] = json.dumps(
             {
-                **settings.CKEDITOR_CONFIGS['link_only'],
-                'extraAllowedContent': 'span(*)[*]{*};ul(*)[*]{*}',
+                **settings.CKEDITOR_CONFIGS['osis_mail_template'],
                 'language': get_language(),
             }
         )
@@ -1117,11 +1116,8 @@ class SicDecisionFinalApprovalForm(forms.Form):
         else:
             self.fields['body'].widget.attrs['data-config'] = json.dumps(
                 {
-                    **settings.CKEDITOR_CONFIGS['link_only'],
-                    'extraAllowedContent': 'span(*)[*]{*};ul(*)[*]{*}',
+                    **settings.CKEDITOR_CONFIGS['osis_mail_template'],
                     'language': get_language(),
-                    'allowedContent': True,
-                    'autoParagraph': False,
                 }
             )
 

--- a/forms/admission/document.py
+++ b/forms/admission/document.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -242,8 +242,7 @@ class RequestAllDocumentsForm(forms.Form):
 
         self.fields['message_content'].widget.attrs['data-config'] = json.dumps(
             {
-                **settings.CKEDITOR_CONFIGS['link_only'],
-                'extraAllowedContent': 'span(*)[*]{*};ul(*)[*]{*}',
+                **settings.CKEDITOR_CONFIGS['osis_mail_template'],
                 'language': get_language(),
             }
         )

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5342,12 +5342,6 @@ msgstr ""
 msgid "Role: ADRE secretary"
 msgstr ""
 
-msgid "Role: Admission reader"
-msgstr ""
-
-msgid "Role: Admission readers"
-msgstr ""
-
 msgid "Role: CDD configurator"
 msgstr ""
 

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -5916,12 +5916,6 @@ msgstr "Rôle: Secrétaires ADRE"
 msgid "Role: ADRE secretary"
 msgstr "Rôle: Secrétaire ADRE"
 
-msgid "Role: Admission reader"
-msgstr "Rôle: Lecteur des demandes d'inscription"
-
-msgid "Role: Admission readers"
-msgstr "Rôle: Lecteurs des demandes d'inscription"
-
 msgid "Role: CDD configurator"
 msgstr "Rôle: Configurateur CDD"
 


### PR DESCRIPTION
Pull request automatique de hotfix/OS-851 vers DEV