### PR TITLE
[hotfix/OS-928 => DEV] Front-office: Blocage d_expérience non-valide provenant d_une autre demande et donc non-modifiable par le candidat > Toutes les expériences venant d_EPC doivent être considérées valides par l_application

### DIFF
--- a/api/schema.py
+++ b/api/schema.py
@@ -32,7 +32,7 @@ from rest_framework.serializers import Serializer
 from backoffice.settings.rest_framework.fields import ActionLinksField
 from base.models.utils.utils import ChoiceEnum
 
-ADMISSION_SDK_VERSION = "1.0.94"
+ADMISSION_SDK_VERSION = "1.0.95"
 
 
 class AdmissionSchemaGenerator(SchemaGenerator):

--- a/api/serializers/curriculum.py
+++ b/api/serializers/curriculum.py
@@ -69,8 +69,8 @@ class ProfessionalExperienceSerializer(serializers.ModelSerializer):
         model = ProfessionalExperience
         exclude = [
             'id',
-            'external_id',
         ]
+        read_only_fields = ['external_id']
 
     @staticmethod
     def get_valuated_from_trainings(value):
@@ -90,7 +90,9 @@ class LiteProfessionalExperienceSerializer(ProfessionalExperienceSerializer):
             'end_date',
             'type',
             'valuated_from_trainings',
+            'external_id',
         ]
+        read_only_fields = ['external_id']
 
 
 class EducationalExperienceYearSerializer(serializers.ModelSerializer):
@@ -155,9 +157,9 @@ class EducationalExperienceSerializer(serializers.ModelSerializer):
         depth = 1
         exclude = [
             'id',
-            'external_id',
             'fwb_equivalent_program',
         ]
+        read_only_fields = ['external_id']
 
     @staticmethod
     def get_valuated_from_trainings(value):
@@ -252,7 +254,9 @@ class LiteEducationalExperienceSerializer(EducationalExperienceSerializer):
             'valuated_from_trainings',
             'country',
             'obtained_diploma',
+            'external_id',
         ]
+        read_only_fields = ['external_id']
 
 
 class DoctoratCompleterCurriculumCommandSerializer(DTOSerializer):

--- a/api/views/curriculum.py
+++ b/api/views/curriculum.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -278,7 +278,7 @@ class ExperienceViewSet(
         return response
 
     def _check_perms_update(self):
-        if self.experience.valuated_from_trainings:
+        if self.experience.valuated_from_trainings or self.experience.external_id:
             raise PermissionDenied(_("This experience cannot be updated as it has already been valuated."))
 
     def update(self, request, *args, **kwargs):
@@ -289,7 +289,7 @@ class ExperienceViewSet(
         return response
 
     def destroy(self, request, *args, **kwargs):
-        if self.experience.valuated_from_trainings:
+        if self.experience.valuated_from_trainings or self.experience.external_id:
             raise PermissionDenied(_("This experience cannot be updated as it has already been valuated."))
 
         response = super().destroy(request, *args, **kwargs)
@@ -338,9 +338,12 @@ class EducationalExperienceViewSet(PersonRelatedMixin, BaseEducationalExperience
 
     def _check_perms_update(self):
         # With doctorate
-        if any(
-            training_type in AnneeInscriptionFormationTranslator.DOCTORATE_EDUCATION_TYPES
-            for training_type in self.experience.valuated_from_trainings
+        if (
+            any(
+                training_type in AnneeInscriptionFormationTranslator.DOCTORATE_EDUCATION_TYPES
+                for training_type in self.experience.valuated_from_trainings
+            )
+            or self.experience.external_id
         ):
             raise PermissionDenied(_("This experience cannot be updated as it has already been valuated."))
 
@@ -353,9 +356,12 @@ class GeneralEducationalExperienceViewSet(GeneralEducationPersonRelatedMixin, Ba
     permission_mapping = GENERAL_EDUCATION_PERMISSIONS_MAPPING
 
     def _check_perms_update(self):
-        if not all(
-            training_type in AnneeInscriptionFormationTranslator.CONTINUING_EDUCATION_TYPES
-            for training_type in self.experience.valuated_from_trainings
+        if (
+            not all(
+                training_type in AnneeInscriptionFormationTranslator.CONTINUING_EDUCATION_TYPES
+                for training_type in self.experience.valuated_from_trainings
+            )
+            or self.experience.external_id
         ):
             raise PermissionDenied(_("This experience cannot be updated as it has already been valuated."))
 

--- a/calendar/admission_calendar.py
+++ b/calendar/admission_calendar.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/ddd/admission/domain/service/i_titres_acces.py
+++ b/ddd/admission/domain/service/i_titres_acces.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/ddd/admission/domain/service/verifier_curriculum.py
+++ b/ddd/admission/domain/service/verifier_curriculum.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -48,6 +48,10 @@ class VerifierCurriculum(interface.DomainService):
         experiences_incompletes = {}
 
         for experience in experiences:
+            # Les expériences qui viennent d'EPC sont considérées complètes qu'elles le soient ou non
+            if experience.epc_experience:
+                continue
+
             pays_belge = experience.pays == BE_ISO_CODE
             traduction_necessaire = (
                 not pays_belge and experience.regime_linguistique not in REGIMES_LINGUISTIQUES_SANS_TRADUCTION

--- a/ddd/admission/formation_generale/test/use_case/read/test_verifier_proposition_service.py
+++ b/ddd/admission/formation_generale/test/use_case/read/test_verifier_proposition_service.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -1532,6 +1532,11 @@ class TestVerifierPropositionService(TestCase):
         self.experiences_academiques.append(self.experience_academiques_complete)
         proposition_id = self.message_bus.invoke(self.cmd(self.master_proposition.entity_id.uuid))
         self.assertEqual(proposition_id, self.master_proposition.entity_id)
+
+    def test_should_verification_etre_ok_avec_experience_academique_epc_incomplete(self):
+        with mock.patch.multiple(self.experience_academiques_complete, identifiant_externe=[]):
+            proposition_id = self.message_bus.invoke(self.cmd(self.master_proposition.entity_id.uuid))
+            self.assertEqual(proposition_id, self.master_proposition.entity_id)
 
     def test_should_verification_renvoyer_erreur_si_releve_notes_global_non_renseigne(self):
         with mock.patch.multiple(self.experience_academiques_complete, releve_notes=[]):

--- a/ddd/admission/test/domain/service/test_calendrier_inscription.py
+++ b/ddd/admission/test/domain/service/test_calendrier_inscription.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/infrastructure/admission/domain/service/in_memory/profil_candidat.py
+++ b/infrastructure/admission/domain/service/in_memory/profil_candidat.py
@@ -179,6 +179,7 @@ class ExperienceAcademique:
     type_institut: str
     cycle_formation: str
     nom_formation_equivalente_communaute_fr: str
+    identifiant_externe: Optional[str] = None
 
 
 @dataclass
@@ -193,6 +194,7 @@ class ExperienceNonAcademique:
     fonction: str
     secteur: str
     autre_activite: str
+    identifiant_externe: Optional[str] = None
 
 
 class ProfilCandidatInMemoryTranslator(IProfilCandidatTranslator):

--- a/infrastructure/admission/domain/service/profil_candidat.py
+++ b/infrastructure/admission/domain/service/profil_candidat.py
@@ -298,6 +298,7 @@ class ProfilCandidatTranslator(IProfilCandidatTranslator):
                 autre_activite=experience.activity,
                 uuid=experience.uuid,
                 valorisee_par_admissions=getattr(experience, 'valuated_from_admissions', None),
+                identifiant_externe=experience.external_id,
             )
             for experience in experiences_non_academiques
         ]
@@ -446,6 +447,7 @@ class ProfilCandidatTranslator(IProfilCandidatTranslator):
                     systeme_evaluation=experience_year.educational_experience.evaluation_type,
                     type_enseignement=experience_year.educational_experience.study_system,
                     valorisee_par_admissions=getattr(experience_year, 'valuated_from_admissions', None),
+                    identifiant_externe=experience_year.educational_experience.external_id,
                     **institute,
                     **linguistic_regime,
                     **program_info,

--- a/schema.yml
+++ b/schema.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Admission API
-  version: 1.0.94
+  version: 1.0.95
   description: This API delivers data for the Admission project.
   contact:
     name: UCLouvain - OSIS
@@ -6789,6 +6789,10 @@ components:
         institute:
           type: string
           nullable: true
+        external_id:
+          type: string
+          readOnly: true
+          nullable: true
         uuid:
           type: string
           readOnly: true
@@ -6892,6 +6896,10 @@ components:
           items:
             type: string
           readOnly: true
+        external_id:
+          type: string
+          readOnly: true
+          nullable: true
         uuid:
           type: string
           readOnly: true
@@ -6965,6 +6973,10 @@ components:
                 items:
                   type: string
                 readOnly: true
+              external_id:
+                type: string
+                readOnly: true
+                nullable: true
             required:
             - start_date
             - end_date
@@ -7011,6 +7023,10 @@ components:
                 nullable: true
               obtained_diploma:
                 type: boolean
+              external_id:
+                type: string
+                readOnly: true
+                nullable: true
             required:
             - educationalexperienceyear_set
             - country


### PR DESCRIPTION
Pull request automatique de hotfix/OS-928 vers DEV