### PR TITLE
[feature/OS-948 => DEV] Back-office: Parcours antérieur > Ne plus exploiter le champ _Formation FWB équivalente_ le cas échéant, et le remplacer par l_intitulé classique

### DIFF
--- a/infrastructure/admission/formation_generale/domain/service/pdf_generation.py
+++ b/infrastructure/admission/formation_generale/domain/service/pdf_generation.py
@@ -211,7 +211,7 @@ class PDFGeneration(IPDFGeneration):
 
                 context['access_titles_names'].append(
                     next(
-                        experience.titre_formate
+                        experience.titre_pdf_decision_fac
                         for experience in {
                             TypeTitreAccesSelectionnable.EXPERIENCE_NON_ACADEMIQUE: cv_dto.experiences_non_academiques,
                             TypeTitreAccesSelectionnable.EXPERIENCE_ACADEMIQUE: cv_dto.experiences_academiques,


### PR DESCRIPTION
- [ ] https://github.com/uclouvain/osis/pull/16411/ must be merged first