### PR TITLE
[feature/OS-975 => DEV] Back-office: Parcours antérieur > Les études secondaires + les formations/activités provenant d_EPC devront être éditables via le module dédié (et non dans Admissions)

### DIFF
--- a/templates/admission/exports/recap/includes/curriculum_professional_experience.html
+++ b/templates/admission/exports/recap/includes/curriculum_professional_experience.html
@@ -6,7 +6,7 @@
   * The core business involves the administration of students, teachers,
   * courses, programs and so on.
   *
-  * Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+  * Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by

--- a/templates/admission/exports/recap/includes/education.html
+++ b/templates/admission/exports/recap/includes/education.html
@@ -6,7 +6,7 @@
   * The core business involves the administration of students, teachers,
   * courses, programs and so on.
   *
-  * Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+  * Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 {% endcomment %}
   {% if formation.type == 'BACHELOR' and etudes_secondaires.diplome_belge %}
 
-    {% panel _('Belgian diploma') edit_link_button=edit_link_button %}
+    {% panel _('Belgian diploma') edit_link_button=edit_link_button edit_link_button_in_new_tab=edit_link_button_in_new_tab %}
 
       {% field_data _('Secondary school graduation year') etudes_secondaires.annee_diplome_etudes_secondaires|get_academic_year %}
 
@@ -53,7 +53,7 @@
 
   {% elif formation.type == 'BACHELOR' and etudes_secondaires.diplome_etranger %}
 
-    {% panel _('Foreign diploma') edit_link_button=edit_link_button %}
+    {% panel _('Foreign diploma') edit_link_button=edit_link_button edit_link_button_in_new_tab=edit_link_button_in_new_tab %}
 
       {% field_data _('Secondary school graduation year') etudes_secondaires.annee_diplome_etudes_secondaires|get_academic_year %}
 
@@ -93,7 +93,7 @@
     {% endif %}
 
   {% elif formation.type == 'BACHELOR' and etudes_secondaires.alternative_secondaires %}
-    {% panel _('Secondary studies') edit_link_button=edit_link_button %}
+    {% panel _('Secondary studies') edit_link_button=edit_link_button edit_link_button_in_new_tab=edit_link_button_in_new_tab %}
       {% field_data _('Do you have a secondary school diploma?') _('No') %}
     {% endpanel %}
     {% if not hide_files %}
@@ -103,7 +103,7 @@
     {% endif %}
 
   {% else %}
-    {% panel _('Secondary studies') edit_link_button=edit_link_button %}
+    {% panel _('Secondary studies') edit_link_button=edit_link_button edit_link_button_in_new_tab=edit_link_button_in_new_tab %}
       {% if etudes_secondaires.diplome_etudes_secondaires == 'YES' %}
         {% blocktranslate trimmed with year=etudes_secondaires.annee_diplome_etudes_secondaires|get_academic_year asvar graduation_text %}
           Yes, in {{ year }}.

--- a/templates/admission/general_education/checklist.html
+++ b/templates/admission/general_education/checklist.html
@@ -62,6 +62,7 @@
     {% can_update_tab 'training-choice' as can_update_training_choice_tab %}
     {% can_update_tab 'specific-questions' as can_update_specific_questions_tab %}
     {% can_update_tab 'curriculum' as can_update_curriculum %}
+    {% can_update_tab 'education' as can_update_education %}
 
     {% if can_update_person_tab %}
       {% url base_namespace|add:":update:person" view.kwargs.uuid as person_url %}
@@ -342,7 +343,7 @@
               {% else %}
                 {% include 'admission/general_education/includes/checklist/previous_experience_single.html' with current=child authentication_form=authentication_forms|get_item_or_none:child.extra.identifiant experience_authentication_history_entry=all_experience_authentication_history_entries|get_item_or_none:child.extra.identifiant %}
                 <div>
-                  {% experience_details_template resume_proposition=resume_proposition experience=experience with_edit_link_button=can_update_curriculum specific_questions=specific_questions_by_tab %}
+                  {% experience_details_template resume_proposition=resume_proposition experience=experience with_edit_link_button=True can_update_curriculum=can_update_curriculum can_update_education=can_update_education specific_questions=specific_questions_by_tab %}
                 </div>
               {% endif %}
             {% endwith %}

--- a/templates/admission/general_education/includes/checklist/parcours_row_actions_links.html
+++ b/templates/admission/general_education/includes/checklist/parcours_row_actions_links.html
@@ -6,7 +6,7 @@
   * The core business involves the administration of students, teachers,
   * courses, programs and so on.
   *
-  * Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+  * Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
@@ -28,6 +28,9 @@
     class="btn btn-info btn-xs"
     aria-label="{% translate "Update experience" %}"
     title="{% translate "Update experience" %}"
+    {% if edit_link_button_in_new_tab %}
+    target="_blank"
+    {% endif %}
   >
     <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
   </a>

--- a/templates/admission/general_education/includes/checklist/previous_experience_single_header_buttons.html
+++ b/templates/admission/general_education/includes/checklist/previous_experience_single_header_buttons.html
@@ -25,14 +25,22 @@
   * see http://www.gnu.org/licenses/.
 {% endcomment %}
 
-{% if edit_link_button %}
+{% if edit_link_button or duplicate_link_button or delete_link_button %}
   <div class="btn-group btn-group-sm" role="group">
-    <a
-        class="btn btn-default"
-        href="{{ edit_link_button }}"
-    >
-      <i class="fas fa-edit"></i>
-    </a>
+
+    {% if edit_link_button %}
+      <a
+          class="btn btn-default"
+          href="{{ edit_link_button }}"
+          aria-label="{% translate "Update experience" %}"
+          title="{% translate "Update experience" %}"
+          {% if edit_link_button_in_new_tab %}
+          target="_blank"
+          {% endif %}
+      >
+        <i class="fas fa-edit"></i>
+      </a>
+    {% endif %}
 
     {% if duplicate_link_button %}
       {% concat 'duplicate-experience-modal-single-' experience.uuid.hex as duplicate_modal_id %}
@@ -40,6 +48,8 @@
           class="btn btn-default"
           data-toggle="modal"
           data-target="#{{ duplicate_modal_id }}"
+          aria-label="{% translate "Duplicate experience" %}"
+          title="{% translate "Duplicate experience" %}"
       >
         <i class="fas fa-copy"></i>
       </button>
@@ -47,12 +57,15 @@
       {% translate 'Are you sure you want to realize this duplication?' as confirm_message %}
       {% include 'admission/modal/confirm_modal.html' with confirm_title=confirm_title confirm_url=duplicate_link_button confirm_message=confirm_message confirm_id=duplicate_modal_id confirm_button_class="btn-primary" %}
     {% endif %}
+
     {% if delete_link_button %}
       {% concat 'delete-experience-modal-single-' experience.uuid.hex as delete_modal_id %}
       <button
           class="btn btn-default"
           data-toggle="modal"
           data-target="#{{ delete_modal_id }}"
+          aria-label="{% translate "Delete experience" %}"
+          title="{% translate "Delete experience" %}"
       >
         <i class="fas fa-xmark"></i>
       </button>
@@ -60,5 +73,6 @@
       {% translate 'Are you sure you want to realize this deletion?' as confirm_message %}
       {% include 'admission/modal/confirm_modal.html' with confirm_title=confirm_title confirm_url=delete_link_button confirm_message=confirm_message confirm_id=delete_modal_id %}
     {% endif %}
+
   </div>
 {% endif %}

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -7,7 +7,7 @@
 * The core business involves the administration of students, teachers,
 * courses, programs and so on.
 *
-* Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+* Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -34,9 +34,12 @@
           tabindex="0"
           {% else %}
           href="{{ edit_link_button }}"
+          {% if edit_link_button_in_new_tab %}
+          target="_blank"
+          {% endif %}
           {% endif %}
       >
-        <i class="fas fa-{% if edit_link_button == 'JS_BUTTON' or 'update' in edit_link_button %}edit{% else %}eye{% endif %}"></i>
+        <i class="fas fa-{% if edit_link_button == 'JS_BUTTON' or 'update' in edit_link_button or 'edit' in edit_link_button %}edit{% else %}eye{% endif %}"></i>
       </a>
     {% endif %}
     <h{{ title_level }} class="panel-title">

--- a/templatetags/admission.py
+++ b/templatetags/admission.py
@@ -216,13 +216,22 @@ def reduce_list_separated(arg1, arg2, separator=", "):
 
 
 @register_panel('panel.html', takes_context=True)
-def panel(context, title='', title_level=4, additional_class='', edit_link_button='', **kwargs):
+def panel(
+    context,
+    title='',
+    title_level=4,
+    additional_class='',
+    edit_link_button='',
+    edit_link_button_in_new_tab=False,
+    **kwargs,
+):
     """
     Template tag for panel
     :param title: the panel title
     :param title_level: the title level
     :param additional_class: css class to add
     :param edit_link_button: url of the edit button
+    :param edit_link_button_in_new_tab: open the edit link in a new tab
     :type context: django.template.context.RequestContext
     """
     context['title'] = title
@@ -230,6 +239,7 @@ def panel(context, title='', title_level=4, additional_class='', edit_link_butto
     context['additional_class'] = additional_class
     if edit_link_button:
         context['edit_link_button'] = edit_link_button
+        context['edit_link_button_in_new_tab'] = edit_link_button_in_new_tab
     context['attributes'] = {k.replace('_', '-'): v for k, v in kwargs.items()}
     return context
 
@@ -1181,6 +1191,8 @@ def experience_details_template(
     specific_questions: Dict[str, List[QuestionSpecifiqueDTO]] = None,
     with_edit_link_button=True,
     hide_files=True,
+    can_update_curriculum=False,
+    can_update_education=False,
 ):
     """
     Return the template used to render the experience details.
@@ -1188,6 +1200,10 @@ def experience_details_template(
     :param resume_proposition: The proposition resume
     :param experience: The experience
     :param specific_questions: The specific questions related to the experience (only used for secondary studies)
+    :param with_edit_link_button: Specify if the edit link button should be displayed
+    :param hide_files: Specify if the files should be hidden
+    :param can_update_curriculum: Specify if the user can update the curriculum
+    :param can_update_education: Specify if the user can update the education
     :return: The rendered template
     """
     next_url_suffix = f'?next={context.get("request").path}&next_hash_url=parcours_anterieur__{experience.uuid}'
@@ -1199,20 +1215,40 @@ def experience_details_template(
         'formation': resume_proposition.proposition.formation,
         'hide_files': hide_files,
         'checklist_display': True,
+        'edit_link_button': '',
+        'duplicate_link_button': '',
+        'delete_link_button': '',
+        'edit_link_button_in_new_tab': experience.epc_experience,
     }
+
     if experience.__class__ == ExperienceAcademiqueDTO:
         res_context['custom_base_template'] = 'admission/exports/recap/includes/curriculum_educational_experience.html'
         res_context['title'] = _('Academic experience')
         res_context['with_single_header_buttons'] = True
 
-        if with_edit_link_button:
-            res_context['edit_link_button'] = (
-                reverse(
-                    'admission:general-education:update:curriculum:educational',
-                    args=[resume_proposition.proposition.uuid, experience.uuid],
+        if with_edit_link_button and can_update_curriculum:
+            if not experience.epc_experience:
+                res_context['edit_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:curriculum:educational',
+                        args=[resume_proposition.proposition.uuid, experience.uuid],
+                    )
+                    + next_url_suffix
                 )
-                + next_url_suffix
-            )
+                res_context['delete_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:curriculum:educational_delete',
+                        args=[resume_proposition.proposition.uuid, experience.uuid],
+                    )
+                    + delete_next_url_suffix
+                )
+
+            elif context['admission'].noma_candidat:
+                res_context['edit_link_button'] = resolve_url(
+                    'edit-experience-academique-view',
+                    noma=context['admission'].noma_candidat,
+                    experience_uuid=experience.annees[0].uuid,
+                )
 
             res_context['duplicate_link_button'] = (
                 reverse(
@@ -1222,19 +1258,6 @@ def experience_details_template(
                 + next_url_suffix
             )
 
-            res_context['delete_link_button'] = (
-                reverse(
-                    'admission:general-education:update:curriculum:educational_delete',
-                    args=[resume_proposition.proposition.uuid, experience.uuid],
-                )
-                + delete_next_url_suffix
-            )
-
-        else:
-            res_context['edit_link_button'] = None
-            res_context['duplicate_link_button'] = None
-            res_context['delete_link_button'] = None
-
         res_context.update(get_educational_experience_context(resume_proposition, experience))
 
     elif experience.__class__ == ExperienceNonAcademiqueDTO:
@@ -1242,14 +1265,30 @@ def experience_details_template(
         res_context['title'] = _('Non-academic experience')
         res_context['with_single_header_buttons'] = True
 
-        if with_edit_link_button:
-            res_context['edit_link_button'] = (
-                reverse(
-                    'admission:general-education:update:curriculum:non_educational',
-                    args=[resume_proposition.proposition.uuid, experience.uuid],
+        if with_edit_link_button and can_update_curriculum:
+            if not experience.epc_experience:
+                res_context['edit_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:curriculum:non_educational',
+                        args=[resume_proposition.proposition.uuid, experience.uuid],
+                    )
+                    + next_url_suffix
                 )
-                + next_url_suffix
-            )
+
+                res_context['delete_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:curriculum:non_educational_delete',
+                        args=[resume_proposition.proposition.uuid, experience.uuid],
+                    )
+                    + delete_next_url_suffix
+                )
+
+            elif context['admission'].noma_candidat:
+                res_context['edit_link_button'] = resolve_url(
+                    'edit-experience-non-academique-view',
+                    noma=context['admission'].noma_candidat,
+                    experience_uuid=experience.uuid,
+                )
 
             res_context['duplicate_link_button'] = (
                 reverse(
@@ -1259,33 +1298,27 @@ def experience_details_template(
                 + next_url_suffix
             )
 
-            res_context['delete_link_button'] = (
-                reverse(
-                    'admission:general-education:update:curriculum:non_educational_delete',
-                    args=[resume_proposition.proposition.uuid, experience.uuid],
-                )
-                + delete_next_url_suffix
-            )
-
-        else:
-            res_context['edit_link_button'] = None
-            res_context['duplicate_link_button'] = None
-            res_context['delete_link_button'] = None
-
         res_context.update(get_non_educational_experience_context(experience))
 
     elif experience.__class__ == EtudesSecondairesAdmissionDTO:
         res_context['custom_base_template'] = 'admission/exports/recap/includes/education.html'
         res_context['etudes_secondaires'] = experience
-        res_context['edit_link_button'] = (
-            reverse(
-                'admission:general-education:update:education',
-                args=[resume_proposition.proposition.uuid],
-            )
-            + next_url_suffix
-            if with_edit_link_button
-            else None
-        )
+
+        if with_edit_link_button and can_update_education:
+            if not experience.epc_experience:
+                res_context['edit_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:education',
+                        args=[resume_proposition.proposition.uuid],
+                    )
+                ) + next_url_suffix
+
+            elif context['admission'].noma_candidat:
+                res_context['edit_link_button'] = resolve_url(
+                    'edit-etudes-secondaires-view',
+                    noma=context['admission'].noma_candidat,
+                )
+
         res_context.update(
             get_secondary_studies_context(
                 resume_proposition,
@@ -1308,59 +1341,94 @@ def checklist_experience_action_links_context(
     base_namespace = context['view'].base_namespace
     proposition_uuid = context['view'].kwargs['uuid']
     proposition_uuid_str = str(proposition_uuid)
+
+    result_context = {
+        'prefix': prefix,
+        'experience_uuid': str(experience.uuid),
+        'edit_link_button_in_new_tab': experience.epc_experience,
+        'update_url': '',
+        'delete_url': '',
+        'duplicate_url': '',
+    }
+
     if experience.__class__ == EtudesSecondairesAdmissionDTO:
-        return {
-            'prefix': prefix,
-            'update_url': resolve_url(
-                f'{base_namespace}:update:education',
-                uuid=proposition_uuid_str,
+        if not experience.epc_experience:
+            result_context['update_url'] = (
+                resolve_url(
+                    f'{base_namespace}:update:education',
+                    uuid=proposition_uuid_str,
+                )
+                + next_url_suffix
             )
-            + next_url_suffix,
-            'experience_uuid': str(experience.uuid),
-        }
+        elif context['admission'].noma_candidat:
+            result_context['update_url'] = resolve_url(
+                'edit-etudes-secondaires-view',
+                noma=context['admission'].noma_candidat,
+            )
     elif proposition_uuid in experience.valorisee_par_admissions and experience.derniere_annee == current_year:
         if experience.__class__ == ExperienceAcademiqueDTO:
-            return {
-                'prefix': prefix,
-                'update_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:educational',
-                    uuid=proposition_uuid_str,
-                    experience_uuid=experience.uuid,
+            result_context['duplicate_url'] = resolve_url(
+                f'{base_namespace}:update:curriculum:educational_duplicate',
+                uuid=proposition_uuid_str,
+                experience_uuid=experience.uuid,
+            )
+
+            if not experience.epc_experience:
+                result_context['update_url'] = (
+                    resolve_url(
+                        f'{base_namespace}:update:curriculum:educational',
+                        uuid=proposition_uuid_str,
+                        experience_uuid=experience.uuid,
+                    )
+                    + next_url_suffix
                 )
-                + next_url_suffix,
-                'delete_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:educational_delete',
-                    uuid=proposition_uuid_str,
-                    experience_uuid=experience.uuid,
-                ),
-                'duplicate_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:educational_duplicate',
-                    uuid=proposition_uuid_str,
-                    experience_uuid=experience.uuid,
-                ),
-                'experience_uuid': str(experience.uuid),
-            }
+                result_context['delete_url'] = (
+                    resolve_url(
+                        f'{base_namespace}:update:curriculum:educational_delete',
+                        uuid=proposition_uuid_str,
+                        experience_uuid=experience.uuid,
+                    )
+                    + next_url_suffix
+                )
+            elif context['admission'].noma_candidat:
+                result_context['update_url'] = resolve_url(
+                    'edit-experience-academique-view',
+                    noma=context['admission'].noma_candidat,
+                    experience_uuid=experience.annees[0].uuid,
+                )
+
         elif experience.__class__ == ExperienceNonAcademiqueDTO:
-            return {
-                'prefix': prefix,
-                'update_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:non_educational',
-                    uuid=proposition_uuid_str,
+            result_context['duplicate_url'] = resolve_url(
+                f'{base_namespace}:update:curriculum:non_educational_duplicate',
+                uuid=proposition_uuid_str,
+                experience_uuid=experience.uuid,
+            )
+
+            if not experience.epc_experience:
+                result_context['update_url'] = (
+                    resolve_url(
+                        f'{base_namespace}:update:curriculum:non_educational',
+                        uuid=proposition_uuid_str,
+                        experience_uuid=experience.uuid,
+                    )
+                    + next_url_suffix
+                )
+                result_context['delete_url'] = (
+                    resolve_url(
+                        f'{base_namespace}:update:curriculum:non_educational_delete',
+                        uuid=proposition_uuid_str,
+                        experience_uuid=experience.uuid,
+                    )
+                    + next_url_suffix
+                )
+            elif context['admission'].noma_candidat:
+                result_context['update_url'] = resolve_url(
+                    'edit-experience-non-academique-view',
+                    noma=context['admission'].noma_candidat,
                     experience_uuid=experience.uuid,
                 )
-                + next_url_suffix,
-                'delete_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:non_educational_delete',
-                    uuid=proposition_uuid_str,
-                    experience_uuid=experience.uuid,
-                ),
-                'duplicate_url': resolve_url(
-                    f'{base_namespace}:update:curriculum:non_educational_duplicate',
-                    uuid=proposition_uuid_str,
-                    experience_uuid=experience.uuid,
-                ),
-                'experience_uuid': str(experience.uuid),
-            }
+
+    return result_context
 
 
 @register.inclusion_tag(

--- a/tests/views/common/form_tabs/curriculum/test_educational_experience.py
+++ b/tests/views/common/form_tabs/curriculum/test_educational_experience.py
@@ -36,6 +36,7 @@ from django.test import TestCase
 from django.utils.translation import gettext
 from rest_framework import status
 
+from admission.contrib.models import EPCInjection as AdmissionEPCInjection
 from admission.contrib.models.base import AdmissionEducationalValuatedExperiences
 from admission.contrib.models.general_education import GeneralEducationAdmission
 from admission.ddd.admission.doctorat.preparation.domain.model.doctorat import ENTITY_CDE
@@ -46,7 +47,11 @@ from admission.ddd.admission.formation_generale.domain.model.enums import (
     ChoixStatutPropositionGenerale,
 )
 from admission.ddd.admission.formation_generale.domain.service.checklist import Checklist
-from admission.tests.factories.curriculum import EducationalExperienceFactory, EducationalExperienceYearFactory
+from admission.tests.factories.curriculum import (
+    EducationalExperienceFactory,
+    EducationalExperienceYearFactory,
+    AdmissionEducationalValuatedExperiencesFactory,
+)
 from admission.tests.factories.faculty_decision import FreeAdditionalApprovalConditionFactory
 from admission.tests.factories.general_education import GeneralEducationAdmissionFactory
 from admission.tests.factories.roles import SicManagementRoleFactory, ProgramManagerRoleFactory
@@ -65,6 +70,7 @@ from base.tests.factories.entity_version import EntityVersionFactory
 from base.tests.factories.organization import OrganizationFactory
 from osis_profile.models import EducationalExperience, EducationalExperienceYear
 from osis_profile.models.enums.curriculum import TranscriptType, Result, EvaluationSystem, Reduction, Grade
+from osis_profile.models.epc_injection import EPCInjection as CurriculumEPCInjection, ExperienceType
 from reference.models.enums.cycle import Cycle
 from reference.tests.factories.country import CountryFactory
 from reference.tests.factories.diploma_title import DiplomaTitleFactory
@@ -183,6 +189,49 @@ class CurriculumEducationalExperienceFormViewTestCase(TestCase):
         response = self.client.get(self.form_url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_update_curriculum_is_not_allowed_for_injected_experiences(self):
+        self.client.force_login(self.sic_manager_user)
+
+        # The experience come from EPC
+        self.experience.external_id = 'EPC1'
+        self.experience.save(update_fields=['external_id'])
+
+        response = self.client.get(self.form_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Reset the experience
+        self.experience.external_id = ''
+        self.experience.save(update_fields=['external_id'])
+
+        # The experience has been injected from the curriculum
+        cv_injection = CurriculumEPCInjection.objects.create(
+            person=self.general_admission.candidate,
+            type_experience=ExperienceType.PROFESSIONAL.name,
+            experience_uuid=self.experience.uuid,
+        )
+
+        response = self.client.get(self.form_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        cv_injection.delete()
+
+        # The admission has been injected
+        admission_injection = AdmissionEPCInjection.objects.create(
+            admission=self.general_admission,
+        )
+
+        response = self.client.get(self.form_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        AdmissionEducationalValuatedExperiencesFactory(
+            baseadmission=self.general_admission, educationalexperience=self.experience
+        )
+
+        response = self.client.get(self.form_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        admission_injection.delete()
 
     def test_form_initialization(self):
         self.client.force_login(self.sic_manager_user)
@@ -1876,6 +1925,51 @@ class CurriculumEducationalExperienceDeleteViewTestCase(TestCase):
         response = self.client.delete(self.delete_url)
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+    def test_delete_experience_from_curriculum_is_not_allowed_for_injected_experiences(self):
+        self.client.force_login(self.sic_manager_user)
+
+        # The experience come from EPC
+        self.experience.external_id = 'EPC1'
+        self.experience.save(update_fields=['external_id'])
+
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Reset the experience
+        self.experience.external_id = ''
+        self.experience.save(update_fields=['external_id'])
+
+        # The experience has been injected from the curriculum
+        cv_injection = CurriculumEPCInjection.objects.create(
+            person=self.general_admission.candidate,
+            type_experience=ExperienceType.PROFESSIONAL.name,
+            experience_uuid=self.experience.uuid,
+        )
+
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        cv_injection.delete()
+
+        # The admission has been injected
+        admission_injection = AdmissionEPCInjection.objects.create(
+            admission=self.general_admission,
+        )
+
+        valuation = AdmissionEducationalValuatedExperiencesFactory(
+            baseadmission=self.general_admission, educationalexperience=self.experience
+        )
+
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        valuation.delete()
+
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        admission_injection.delete()
 
     def test_delete_experience_from_curriculum_and_redirect(self):
         self.client.force_login(self.sic_manager_user)


### PR DESCRIPTION
- [ ] https://github.com/uclouvain/osis/pull/16440 must be merged first