### PR TITLE
[hotfix/OS-1143 => MASTER] Back-office: Vues du parcours annualisé > Les expériences du currext provenant d_EPC ne doivent pas être directement éditables, ni dupliquables

### DIFF
--- a/templates/admission/general_education/includes/checklist/parcours_externe_button.html
+++ b/templates/admission/general_education/includes/checklist/parcours_externe_button.html
@@ -1,0 +1,37 @@
+{% load i18n strings %}
+
+{% comment "License" %}
+  * OSIS stands for Open Student Information System. It's an application
+  * designed to manage the core business of higher education institutions,
+  * such as universities, faculties, institutes and professional schools.
+  * The core business involves the administration of students, teachers,
+  * courses, programs and so on.
+  *
+  * Copyright (C) 2015-2024 Université catholique de Louvain
+  (http://www.uclouvain.be)
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * A copy of this license - GNU General Public License - is available
+  * at the root of the source code of this program.  If not,
+  * see http://www.gnu.org/licenses/.
+{% endcomment %}
+<a
+    href="{{ curex_url }}"
+    class="btn btn-link"
+    aria-label="Aller vers le parcours externe"
+    title="Aller vers le parcours externe"
+    {% if edit_link_button_in_new_tab %}
+    target="_blank"
+    {% endif %}
+>
+    <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
+</a>

--- a/templates/admission/general_education/includes/checklist/parcours_row_actions_links.html
+++ b/templates/admission/general_education/includes/checklist/parcours_row_actions_links.html
@@ -22,6 +22,9 @@
   * at the root of the source code of this program.  If not,
   * see http://www.gnu.org/licenses/.
 {% endcomment %}
+{% if curex_url %}
+    {% include 'admission/general_education/includes/checklist/parcours_externe_button.html' with curex_url=curex_url %}
+{% endif %}
 {% if update_url %}
   <a
     href="{{ update_url }}"

--- a/templates/admission/general_education/includes/checklist/previous_experience_single_header_buttons.html
+++ b/templates/admission/general_education/includes/checklist/previous_experience_single_header_buttons.html
@@ -29,9 +29,11 @@
   {% include 'admission/includes/back_to_cv_overview_link.html' %}
 {% endif %}
 
-{% if edit_link_button or duplicate_link_button or delete_link_button %}
+{% if edit_link_button or duplicate_link_button or delete_link_button or curex_link_button %}
   <div class="btn-group btn-group-sm" role="group">
-
+    {% if curex_link_button %}
+        {% include 'admission/general_education/includes/checklist/parcours_externe_button.html' with curex_url=curex_link_button %}
+    {% endif %}
     {% if edit_link_button %}
       <a
           class="btn btn-default"

--- a/templatetags/admission.py
+++ b/templatetags/admission.py
@@ -40,6 +40,7 @@ from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import SafeString, mark_safe
 from django.utils.translation import get_language, gettext_lazy as _, pgettext, gettext
 from osis_comment.models import CommentEntry
+from osis_document.api.utils import get_remote_metadata, get_remote_token
 from osis_history.models import HistoryEntry
 from rules.templatetags import rules
 
@@ -72,7 +73,6 @@ from admission.ddd.admission.enums import TypeItemFormulaire, Onglets
 from admission.ddd.admission.enums.emplacement_document import StatutReclamationEmplacementDocument
 from admission.ddd.admission.formation_continue.domain.model.enums import (
     ChoixStatutPropositionContinue,
-    STATUTS_PROPOSITION_CONTINUE_SOUMISE,
     ChoixMoyensDecouverteFormation,
 )
 from admission.ddd.admission.formation_continue.domain.model.statut_checklist import (
@@ -81,7 +81,6 @@ from admission.ddd.admission.formation_continue.domain.model.statut_checklist im
 from admission.ddd.admission.formation_continue.dtos.proposition import PropositionDTO as PropositionContinueDTO
 from admission.ddd.admission.formation_generale.domain.model.enums import (
     ChoixStatutPropositionGenerale,
-    STATUTS_PROPOSITION_GENERALE_SOUMISE,
     STATUTS_PROPOSITION_GENERALE_SOUMISE_POUR_SIC,
     ChoixStatutChecklist,
 )
@@ -116,7 +115,6 @@ from ddd.logic.financabilite.domain.model.enums.situation import SituationFinanc
 from ddd.logic.shared_kernel.campus.dtos import UclouvainCampusDTO
 from ddd.logic.shared_kernel.profil.dtos.parcours_externe import ExperienceAcademiqueDTO, ExperienceNonAcademiqueDTO
 from ddd.logic.shared_kernel.profil.dtos.parcours_interne import ExperienceParcoursInterneDTO
-from osis_document.api.utils import get_remote_metadata, get_remote_token
 from osis_role.contrib.permissions import _get_roles_assigned_to_user
 from osis_role.templatetags.osis_role import has_perm
 from reference.models.country import Country
@@ -1346,6 +1344,13 @@ def experience_details_template(
 
         if with_edit_link_button and can_update_curriculum:
             if not experience.epc_experience:
+                res_context['duplicate_link_button'] = (
+                    reverse(
+                        'admission:general-education:update:curriculum:educational_duplicate',
+                        args=[resume_proposition.proposition.uuid, experience.uuid],
+                    )
+                    + next_url_suffix
+                )
                 res_context['edit_link_button'] = (
                     reverse(
                         'admission:general-education:update:curriculum:educational',
@@ -1362,19 +1367,10 @@ def experience_details_template(
                 )
 
             elif context['admission'].noma_candidat:
-                res_context['edit_link_button'] = resolve_url(
-                    'edit-experience-academique-view',
+                res_context['curex_link_button'] = resolve_url(
+                    'parcours-externe-view',
                     noma=context['admission'].noma_candidat,
-                    experience_uuid=experience.annees[0].uuid,
                 )
-
-            res_context['duplicate_link_button'] = (
-                reverse(
-                    'admission:general-education:update:curriculum:educational_duplicate',
-                    args=[resume_proposition.proposition.uuid, experience.uuid],
-                )
-                + next_url_suffix
-            )
 
         res_context.update(get_educational_experience_context(resume_proposition, experience))
 
@@ -1497,13 +1493,12 @@ def checklist_experience_action_links_context(
         and experience.derniere_annee == current_year
     ):
         if experience.__class__ == ExperienceAcademiqueDTO:
-            result_context['duplicate_url'] = resolve_url(
-                f'{base_namespace}:update:curriculum:educational_duplicate',
-                uuid=proposition_uuid_str,
-                experience_uuid=experience.uuid,
-            )
-
             if not experience.epc_experience:
+                result_context['duplicate_url'] = resolve_url(
+                    f'{base_namespace}:update:curriculum:educational_duplicate',
+                    uuid=proposition_uuid_str,
+                    experience_uuid=experience.uuid,
+                )
                 result_context['update_url'] = (
                     resolve_url(
                         f'{base_namespace}:update:curriculum:educational',
@@ -1521,10 +1516,9 @@ def checklist_experience_action_links_context(
                     + next_url_suffix
                 )
             elif context['admission'].noma_candidat:
-                result_context['update_url'] = resolve_url(
-                    'edit-experience-academique-view',
+                result_context['curex_url'] = resolve_url(
+                    'parcours-externe-view',
                     noma=context['admission'].noma_candidat,
-                    experience_uuid=experience.annees[0].uuid,
                 )
 
         elif experience.__class__ == ExperienceNonAcademiqueDTO:

--- a/tests/templatetags/test_admission.py
+++ b/tests/templatetags/test_admission.py
@@ -617,10 +617,9 @@ class DisplayTagTestCase(TestCase):
         template_params = experience_details_template(**kwargs)
 
         self.assertEqual(
-            template_params['edit_link_button'],
-            '/osis_profile/{noma}/parcours_externe/edit/experience_academique/{annee_experience_uuid}'.format(
+            template_params['curex_link_button'],
+            '/osis_profile/{noma}/parcours_externe/'.format(
                 noma='0123456',
-                annee_experience_uuid=kwargs['experience'].annees[0].uuid,
             ),
         )
         self.assertEqual(template_params['delete_link_button'], '')
@@ -817,8 +816,8 @@ class DisplayTagTestCase(TestCase):
 
         self.assertEqual(context['edit_link_button_in_new_tab'], True)
         self.assertEqual(
-            context['update_url'],
-            f'/osis_profile/0123456/parcours_externe/edit/experience_academique/{experience.annees[0].uuid}',
+            context['curex_url'],
+            '/osis_profile/0123456/parcours_externe/',
         )
         self.assertEqual(context['delete_url'], '')
 


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1143 vers MASTER