### PR TITLE
[hotfix/OS-1140 => QA] Front-office: Demandes W-MEDE24-0002.2786, L-TECO24-0002.2903, L-PSP24-0002.2672 (brouillons) bloquées lors du clic sur le bouton d_envoi - message _erreur inattendue_ - certificats 9CE (formation générale)

### DIFF
--- a/ddd/admission/formation_generale/domain/model/proposition.py
+++ b/ddd/admission/formation_generale/domain/model/proposition.py
@@ -794,11 +794,14 @@ class Proposition(interface.RootEntity):
     def specifier_financabilite_resultat_calcul(
         self,
         financabilite_regle_calcule: EtatFinancabilite,
-        financabilite_regle_calcule_situation: SituationFinancabilite,
+        financabilite_regle_calcule_situation: str,
         auteur_modification: Optional[str] = '',
     ):
         self.financabilite_regle_calcule = financabilite_regle_calcule
-        self.financabilite_regle_calcule_situation = financabilite_regle_calcule_situation
+        self.financabilite_regle_calcule_situation = (
+            SituationFinancabilite[financabilite_regle_calcule_situation]
+            if financabilite_regle_calcule_situation else ''
+        )
         self.financabilite_regle_calcule_le = now()
         if auteur_modification:
             self.auteur_derniere_modification = auteur_modification

--- a/ddd/admission/formation_generale/use_case/write/soumettre_proposition_service.py
+++ b/ddd/admission/formation_generale/use_case/write/soumettre_proposition_service.py
@@ -178,7 +178,7 @@ def soumettre_proposition(
 
     proposition.specifier_financabilite_resultat_calcul(
         financabilite_regle_calcule=EtatFinancabilite[financabilite.etat],
-        financabilite_regle_calcule_situation=SituationFinancabilite[financabilite.situation],
+        financabilite_regle_calcule_situation=financabilite.situation,
     )
 
     Checklist.initialiser(

--- a/ddd/admission/formation_generale/use_case/write/specifier_financabilite_resultat_calcul_service.py
+++ b/ddd/admission/formation_generale/use_case/write/specifier_financabilite_resultat_calcul_service.py
@@ -44,7 +44,7 @@ def specifier_financabilite_resultat_calcul(
     # THEN
     proposition.specifier_financabilite_resultat_calcul(
         financabilite_regle_calcule=EtatFinancabilite[cmd.financabilite_regle_calcule],
-        financabilite_regle_calcule_situation=SituationFinancabilite[cmd.financabilite_regle_calcule_situation],
+        financabilite_regle_calcule_situation=cmd.financabilite_regle_calcule_situation,
     )
     proposition_repository.save(proposition)
 


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1140 vers QA