### PR TITLE
[hotfix/OS-1149 => QA] Back-office: Tous les documents considérés _obligatoires_ sont automatiquement placés en _à réclamer immédiatement_ > Retrait intégral de ce mécanisme

### DIFF
--- a/tests/views/common/form_tabs/accounting/test_doctorate.py
+++ b/tests/views/common/form_tabs/accounting/test_doctorate.py
@@ -368,7 +368,7 @@ class DoctorateAccountingFormViewTestCase(TestCase):
         self.assertEqual(accounting.sport_affiliation, '')
         self.assertEqual(self.doctorate_admission.last_update_author, self.sic_manager_user.person)
         self.assertEqual(self.doctorate_admission.modified_at, datetime.datetime.now())
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.doctorate_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/accounting/test_general.py
+++ b/tests/views/common/form_tabs/accounting/test_general.py
@@ -398,7 +398,7 @@ class GeneralAccountingFormViewTestCase(TestCase):
         self.assertEqual(accounting.sport_affiliation, ChoixAffiliationSport.NON.name)
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.now())
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/curriculum/educational_experience_update/test_doctorate.py
+++ b/tests/views/common/form_tabs/curriculum/educational_experience_update/test_doctorate.py
@@ -595,7 +595,7 @@ class CurriculumEducationalExperienceFormViewForDoctorateTestCase(TestCase):
         self.doctorate_admission.refresh_from_db()
         self.assertEqual(self.doctorate_admission.modified_at, datetime.datetime.now())
         self.assertEqual(self.doctorate_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.doctorate_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/curriculum/educational_experience_update/test_general.py
+++ b/tests/views/common/form_tabs/curriculum/educational_experience_update/test_general.py
@@ -1574,7 +1574,7 @@ class CurriculumEducationalExperienceFormViewForGeneralTestCase(TestCase):
         self.general_admission.refresh_from_db()
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.now())
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/curriculum/test_educational_experience_delete.py
+++ b/tests/views/common/form_tabs/curriculum/test_educational_experience_delete.py
@@ -320,7 +320,7 @@ class CurriculumEducationalExperienceDeleteViewTestCase(TestCase):
 
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.today())
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/curriculum/test_non_educational_experience_delete.py
+++ b/tests/views/common/form_tabs/curriculum/test_non_educational_experience_delete.py
@@ -237,7 +237,7 @@ class CurriculumNonEducationalExperienceDeleteViewTestCase(TestCase):
         )
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.today())
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/curriculum/test_non_educational_experience_update.py
+++ b/tests/views/common/form_tabs/curriculum/test_non_educational_experience_update.py
@@ -409,7 +409,7 @@ class CurriculumNonEducationalExperienceFormViewTestCase(TestCase):
         self.general_admission.refresh_from_db()
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.now())
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/test_coordonnees.py
+++ b/tests/views/common/form_tabs/test_coordonnees.py
@@ -408,7 +408,7 @@ class CoordonneesFormTestCase(TestCase):
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.now())
 
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/test_education.py
+++ b/tests/views/common/form_tabs/test_education.py
@@ -251,7 +251,7 @@ class AdmissionEducationFormViewForMasterTestCase(TestCase):
 
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.now())
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.general_admission.requested_documents,
         )
@@ -753,7 +753,7 @@ class AdmissionEducationFormViewForContinuingTestCase(TestCase):
         # Check additional updates
         self.assertEqual(self.continuing_admission.modified_at, datetime.datetime.now())
         self.assertEqual(self.continuing_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.continuing_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/test_person.py
+++ b/tests/views/common/form_tabs/test_person.py
@@ -782,7 +782,7 @@ class PersonFormTestCase(TestCase):
 
         self.general_admission.refresh_from_db()
 
-        self.assertIn(transcript_identifier, self.general_admission.requested_documents)
+        self.assertNotIn(transcript_identifier, self.general_admission.requested_documents)
 
     def test_general_person_form_post_with_invalid_data(self):
         self.client.force_login(user=self.sic_manager_user)

--- a/tests/views/common/form_tabs/test_specific_questions.py
+++ b/tests/views/common/form_tabs/test_specific_questions.py
@@ -317,7 +317,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
         self.assertEqual(general_admission.registration_change_form, [])
         self.assertEqual(general_admission.modified_at, datetime.datetime.today())
         self.assertEqual(general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             general_admission.requested_documents,
         )
@@ -423,7 +423,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
         self.assertEqual(general_admission.registration_change_form, [])
         self.assertEqual(general_admission.modified_at, datetime.datetime.today())
         self.assertEqual(general_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             general_admission.requested_documents,
         )

--- a/tests/views/common/form_tabs/training_choice/test_general.py
+++ b/tests/views/common/form_tabs/training_choice/test_general.py
@@ -297,7 +297,7 @@ class GeneralTrainingChoiceFormViewTestCase(TestCase):
         )
         self.assertEqual(self.master_admission.modified_at, datetime.datetime.today())
         self.assertEqual(self.master_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.master_admission.requested_documents,
         )
@@ -461,7 +461,7 @@ class GeneralTrainingChoiceFormViewTestCase(TestCase):
 
         self.assertEqual(self.bachelor_admission.modified_at, datetime.datetime.today())
         self.assertEqual(self.bachelor_admission.last_update_author, self.sic_manager_user.person)
-        self.assertIn(
+        self.assertNotIn(
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             self.bachelor_admission.requested_documents,
         )

--- a/views/common/detail_tabs/document.py
+++ b/views/common/detail_tabs/document.py
@@ -442,7 +442,6 @@ class DeleteDocumentView(DocumentFormView):
 
         if self.document:
             if self.document.type in EMPLACEMENTS_DOCUMENTS_RECLAMABLES:
-                self.admission.update_requested_documents()
                 self.htmx_trigger_form_extra['next'] = 'missing'
 
         self.htmx_trigger_form_extra['refresh_details'] = document_id.identifiant
@@ -595,9 +594,6 @@ class UploadDocumentByManagerView(DocumentFormView):
         )
 
         if self.document:
-            if self.document.type == TypeEmplacementDocument.NON_LIBRE.name:
-                self.admission.update_requested_documents()
-
             self.htmx_trigger_form_extra['next'] = (
                 'received' if self.document.type in EMPLACEMENTS_DOCUMENTS_RECLAMABLES else 'uclouvain'
             )

--- a/views/common/form_tabs/accounting.py
+++ b/views/common/form_tabs/accounting.py
@@ -45,7 +45,6 @@ class AccountingFormView(AccountingMixinView, FormView):
     template_name = 'admission/forms/accounting.html'
     permission_required = 'admission.change_admission_accounting'
     urlpatterns = 'accounting'
-    update_requested_documents = True
     form_class = AccountingForm
     command_class = {
         CONTEXT_GENERAL: CompleterComptabilitePropositionGeneraleCommand,

--- a/views/common/form_tabs/coordonnees.py
+++ b/views/common/form_tabs/coordonnees.py
@@ -39,7 +39,6 @@ __all__ = ['AdmissionCoordonneesFormView']
 class AdmissionCoordonneesFormView(AdmissionFormMixin, LoadDossierViewMixin, FormView):
     template_name = 'admission/forms/coordonnees.html'
     permission_required = 'admission.change_admission_coordinates'
-    update_requested_documents = True
     update_admission_author = True
 
     def __init__(self, *args, **kwargs):
@@ -84,9 +83,8 @@ class AdmissionCoordonneesFormView(AdmissionFormMixin, LoadDossierViewMixin, For
 
         form_valid = super().form_valid(forms)
         from infrastructure.messages_bus import message_bus_instance
-        message_bus_instance.publish(
-            CoordonneesCandidatModifiees(matricule=self.admission.candidate.global_id)
-        )
+
+        message_bus_instance.publish(CoordonneesCandidatModifiees(matricule=self.admission.candidate.global_id))
         return form_valid
 
     def update_current_admission_on_form_valid(self, form, admission):

--- a/views/common/form_tabs/curriculum.py
+++ b/views/common/form_tabs/curriculum.py
@@ -79,7 +79,6 @@ class CurriculumEducationalExperienceFormView(AdmissionFormMixin, LoadDossierVie
     }
     template_name = 'admission/forms/curriculum_educational_experience.html'
     permission_required = 'admission.change_admission_curriculum'
-    update_requested_documents = True
     update_admission_author = True
 
     def has_permission(self):
@@ -175,7 +174,6 @@ class CurriculumNonEducationalExperienceFormView(
     }
     template_name = 'admission/forms/curriculum_non_educational_experience.html'
     permission_required = 'admission.change_admission_curriculum'
-    update_requested_documents = True
     update_admission_author = True
 
     @property
@@ -326,8 +324,6 @@ class CurriculumBaseDeleteView(LoadDossierViewMixin, DeleteEducationalExperience
 
         admission.save()
 
-        self.admission.update_requested_documents()
-
         return delete
 
     def get_success_url(self):
@@ -384,7 +380,6 @@ class CurriculumBaseExperienceDuplicateView(AdmissionFormMixin, LoadDossierViewM
     template_name = 'admission/empty_template.html'
     form_class = forms.Form
     update_admission_author = True
-    update_requested_documents = True
 
     experience_model = None  # Name of the model of the experience to duplicate
     valuated_experience_model = None  # Name of the model of the valuated experience
@@ -540,7 +535,6 @@ class CurriculumBaseExperienceValuateView(AdmissionFormMixin, LoadDossierViewMix
     experience_model = None
     valuated_experience_model = None
     valuated_experience_field_id_name = None
-    update_requested_documents = True
     update_admission_author = True
     message_on_success = _('The experience has been valuated.')
 

--- a/views/common/form_tabs/curriculum_global.py
+++ b/views/common/form_tabs/curriculum_global.py
@@ -55,7 +55,6 @@ class CurriculumGlobalFormView(AdmissionFormMixin, CurriculumGlobalCommonViewMix
     template_name = 'admission/forms/curriculum.html'
     permission_required = 'admission.change_admission_curriculum'
     form_class = GlobalCurriculumForm
-    update_requested_documents = True
     extra_context = {
         'force_form': True,
     }

--- a/views/common/form_tabs/education.py
+++ b/views/common/form_tabs/education.py
@@ -48,7 +48,6 @@ class AdmissionEducationFormView(AdmissionFormMixin, LoadDossierViewMixin, EditE
     urlpatterns = 'education'
     template_name = 'admission/forms/education.html'
     specific_questions_tab = Onglets.ETUDES_SECONDAIRES
-    update_requested_documents = True
     update_admission_author = True
     permission_required = 'admission.change_admission_secondary_studies'
     foreign_form_class = AdmissionBachelorEducationForeignDiplomaForm

--- a/views/common/form_tabs/person.py
+++ b/views/common/form_tabs/person.py
@@ -40,7 +40,6 @@ class AdmissionPersonFormView(AdmissionFormMixin, LoadDossierViewMixin, UpdateVi
     template_name = 'admission/forms/person.html'
     permission_required = 'admission.change_admission_person'
     form_class = AdmissionPersonForm
-    update_requested_documents = True
     update_admission_author = True
 
     def get_object(self):

--- a/views/common/form_tabs/specific_questions.py
+++ b/views/common/form_tabs/specific_questions.py
@@ -48,7 +48,6 @@ from osis_profile import BE_ISO_CODE
 class SpecificQuestionsFormView(SpecificQuestionsMixinView, FormView):
     permission_required = 'admission.change_admission_specific_questions'
     urlpatterns = 'specific-questions'
-    update_requested_documents = True
 
     def get_template_names(self):
         return [

--- a/views/common/form_tabs/training_choice.py
+++ b/views/common/form_tabs/training_choice.py
@@ -51,7 +51,6 @@ __all__ = ['AdmissionTrainingChoiceFormView']
 class AdmissionTrainingChoiceFormView(AdmissionFormMixin, LoadDossierViewMixin, FormView):
     template_name = 'admission/forms/training_choice.html'
     permission_required = 'admission.change_admission_training_choice'
-    update_requested_documents = True
     urlpatterns = 'training-choice'
     specific_questions_tab = Onglets.CHOIX_FORMATION
 

--- a/views/common/mixins.py
+++ b/views/common/mixins.py
@@ -38,7 +38,9 @@ from admission.auth.roles.central_manager import CentralManager
 from admission.auth.roles.sic_management import SicManagement
 from admission.constants import CONTEXT_DOCTORATE, CONTEXT_GENERAL, CONTEXT_CONTINUING
 from admission.contrib.models import (
-    DoctorateAdmission, GeneralEducationAdmission, ContinuingEducationAdmission,
+    DoctorateAdmission,
+    GeneralEducationAdmission,
+    ContinuingEducationAdmission,
     EPCInjection,
 )
 from admission.contrib.models.base import AdmissionViewer
@@ -297,7 +299,6 @@ class LoadDossierViewMixin(AdmissionViewMixin):
 class AdmissionFormMixin(AdmissionViewMixin):
     message_on_success = _('Your data have been saved.')
     message_on_failure = _('Some errors have been encountered.')
-    update_requested_documents = False
     update_admission_author = False
     default_htmx_trigger_form_extra = {}
     close_modal_on_htmx_request = True
@@ -335,10 +336,6 @@ class AdmissionFormMixin(AdmissionViewMixin):
             # Additional updates if needed
             self.update_current_admission_on_form_valid(form, admission)
             admission.save()
-
-        # Update the requested documents
-        if self.update_requested_documents and hasattr(self.admission, 'update_requested_documents'):
-            self.admission.update_requested_documents()
 
         if self.request.htmx:
             self.htmx_trigger_form(is_valid=True)

--- a/views/doctorate/forms/languages.py
+++ b/views/doctorate/forms/languages.py
@@ -42,7 +42,6 @@ class DoctorateAdmissionLanguagesFormView(AdmissionFormMixin, LoadDossierViewMix
     permission_required = 'admission.change_admission_languages'
     form_class = DoctorateAdmissionLanguagesKnowledgeFormSet
     update_admission_author = True
-    update_requested_documents = True
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1149 vers QA