### PR TITLE
Fix OS-1258: Back-office: Identification + Coordonnées > Demande pas …

### DIFF
--- a/auth/roles/central_manager.py
+++ b/auth/roles/central_manager.py
@@ -73,12 +73,14 @@ class CentralManager(EntityRoleModel):
             'admission.appose_sic_notice': is_entity_manager,
             'admission.view_admission_person': is_entity_manager,
             'admission.change_admission_person': is_entity_manager
-            & (general.in_sic_status | continuing.in_manager_status | doctorate.in_sic_status)
+            & (general.in_sic_status | continuing.in_manager_status | doctorate.in_sic_status
+               | general.in_progress | continuing.in_progress | doctorate.in_progress)
             & ~is_sent_to_epc
             & ~pending_digit_ticket_response,
             'admission.view_admission_coordinates': is_entity_manager,
             'admission.change_admission_coordinates': is_entity_manager
-            & (general.in_sic_status | continuing.in_manager_status | doctorate.in_sic_status)
+            & (general.in_sic_status | continuing.in_manager_status | doctorate.in_sic_status
+               | general.in_progress | continuing.in_progress | doctorate.in_progress)
             & ~is_sent_to_epc
             & ~pending_digit_ticket_response,
             'admission.view_admission_training_choice': is_entity_manager,


### PR DESCRIPTION
…encore envoyée > Permettre aux gestionnaires centraux & direction SIC d'éditer les informations