### PR TITLE
Fix OS-1264: Front-office: Demande L-SC24-0003.3004 (Pierre Blondiau) bloquée à l'écran de confirmation/finalisation

### DIFF
--- a/infrastructure/admission/repository/digit.py
+++ b/infrastructure/admission/repository/digit.py
@@ -281,7 +281,7 @@ class DigitRepository(IDigitRepository):
         # Check person in EPC
         noma_from_epc = _find_student_registration_id_in_epc(matricule=candidate.global_id)
         if noma_from_epc:
-            return noma_from_epc
+            return f"{noma_from_epc:08}"
 
 
 def _retrieve_person_ticket_status(request_id: int):


### PR DESCRIPTION
À voir ce que renvois EPC :

```python
def _find_student_registration_id_in_epc(matricule):
    try:
        url = f"{settings.ESB_STUDENT_API}/{matricule}"
        response = requests.get(url, headers={"Authorization": settings.ESB_AUTHORIZATION})
        result = response.json()
        if response.status_code == 200 and result.get('lireDossierEtudiantResponse'):
            if result['lireDossierEtudiantResponse'].get('return'):
                return result['lireDossierEtudiantResponse']['return'].get('noma')
    except (RequestException, ValueError) as e:
        return None
```

Si c'est un entier alors cette PR devrait corriger le problème.