### PR TITLE
[hotfix/OS-1265 => DEV] Back-office > Parcours antérieur & vues du parcours annualisé > Lorsque le parcours est à l_état _Suffisant_ : la condition d_accès, son millésime et les cases à cocher du titre d_accès seront en lecture seule

### DIFF
--- a/auth/roles/central_manager.py
+++ b/auth/roles/central_manager.py
@@ -36,6 +36,7 @@ from admission.auth.predicates.common import (
     is_entity_manager,
     is_sent_to_epc,
     pending_digit_ticket_response,
+    past_experiences_checklist_tab_is_not_sufficient,
 )
 from education_group.auth.scope import Scope
 from osis_role.contrib.models import EntityRoleModel
@@ -163,10 +164,9 @@ class CentralManager(EntityRoleModel):
             & ~is_sent_to_epc,
             'admission.checklist_select_access_title': is_entity_manager
             & (general.in_sic_status | doctorate.in_sic_status)
+            & past_experiences_checklist_tab_is_not_sufficient
             & ~is_sent_to_epc,
-            'admission.checklist_change_training_choice': is_entity_manager
-            & doctorate.in_sic_status
-            & ~is_sent_to_epc,
+            'admission.checklist_change_training_choice': is_entity_manager & doctorate.in_sic_status & ~is_sent_to_epc,
             'admission.checklist_change_sic_comment': is_entity_manager
             & (general.is_submitted | doctorate.is_submitted)
             & ~is_sent_to_epc,

--- a/auth/roles/program_manager.py
+++ b/auth/roles/program_manager.py
@@ -34,6 +34,7 @@ from admission.auth.predicates.common import (
     is_debug,
     is_sent_to_epc,
     pending_digit_ticket_response,
+    past_experiences_checklist_tab_is_not_sufficient,
 )
 from admission.auth.predicates import general, continuing, doctorate
 from admission.infrastructure.admission.domain.service.annee_inscription_formation import (
@@ -166,6 +167,7 @@ class ProgramManager(EducationGroupRoleModel):
             & ~is_sent_to_epc,
             'admission.checklist_select_access_title': is_part_of_education_group
             & (general.in_fac_status | doctorate.in_fac_status)
+            & past_experiences_checklist_tab_is_not_sufficient
             & ~is_sent_to_epc,
             'admission.checklist_change_fac_comment': is_part_of_education_group & ~is_sent_to_epc,
             'admission.checklist_financability_dispensation_fac': is_part_of_education_group & ~is_sent_to_epc,

--- a/forms/admission/checklist.py
+++ b/forms/admission/checklist.py
@@ -690,6 +690,10 @@ class PastExperiencesAdmissionRequirementForm(forms.ModelForm):
             type_formation=self.instance.training.education_group_type.name,
         )
 
+        if self.instance.checklist.get('current', {}).get('parcours_anterieur', {}).get('statut') == 'GEST_REUSSITE':
+            self.fields['admission_requirement'].disabled = True
+            self.fields['admission_requirement_year'].disabled = True
+
         for field in self.fields.values():
             field.widget.attrs['class'] = 'past-experiences-admission-requirement-field'
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -6774,6 +6774,11 @@ msgid ""
 "this action."
 msgstr ""
 
+msgid ""
+"The Previous experience must not be in the \"Sufficient\" status in order to "
+"do this action."
+msgstr ""
+
 #, python-format
 msgid ""
 "The SIC decision mail was sent to the candidate the %(date)s by %(author)s."

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -7484,6 +7484,13 @@ msgstr ""
 "Le parcours antérieur doit être à l'état \"Suffisant\" pour pouvoir "
 "effectuer cette action."
 
+msgid ""
+"The Previous experience must not be in the \"Sufficient\" status in order to "
+"do this action."
+msgstr ""
+"Le parcours antérieur ne doit pas être à l'état \"Suffisant\" pour pouvoir "
+"effectuer cette action."
+
 #, python-format
 msgid ""
 "The SIC decision mail was sent to the candidate the %(date)s by %(author)s."

--- a/templates/admission/doctorate/checklist.html
+++ b/templates/admission/doctorate/checklist.html
@@ -891,7 +891,14 @@
                       $('.' + accessTitleClass).prop('checked', elt.checked);
                   }
               }
-          })
+          });
+
+          $('#parcours_anterieur').on('formValidation', '.checklist-state-button', function(event) {
+              {# The access titles can be updated only if the fac decision status is not sufficient. #}
+              if (event.originalEvent.detail.select_access_title_perm !== undefined) {
+                $('input[name="access-title"]').prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+              }
+          });
 
           // SIC decision
           const sicDecisionContainer = $('#decision_sic');

--- a/templates/admission/general_education/checklist.html
+++ b/templates/admission/general_education/checklist.html
@@ -989,7 +989,14 @@
                       $('.' + accessTitleClass).prop('checked', elt.checked);
                   }
               }
-          })
+          });
+
+          $('#parcours_anterieur').on('formValidation', '.checklist-state-button', function(event) {
+              {# The access titles can be updated only if the fac decision status is not sufficient. #}
+              if (event.originalEvent.detail.select_access_title_perm !== undefined) {
+                $('input[name="access-title"]').prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+              }
+          });
 
           // SIC decision
           const sicDecisionContainer = $('#decision_sic');

--- a/templates/admission/general_education/includes/checklist/previous_experiences.html
+++ b/templates/admission/general_education/includes/checklist/previous_experiences.html
@@ -53,5 +53,8 @@
     {# Update the checklist menu item status #}
     {% include "admission/general_education/checklist_menu_item_status.html" with statut=current.statut item_name='parcours_anterieur' %}
     {% include 'admission/general_education/includes/checklist/sic_decision_statuses.html' with proposition=admission current=original_admission.checklist.current.decision_sic %}
+
+    {# Update the access condition form #}
+    {% include 'admission/general_education/includes/checklist/previous_experiences_admission_requirement_form.html' with with_swap_oob=True %}
   {% endif %}
 {% endwith %}

--- a/templates/admission/general_education/includes/checklist/previous_experiences_admission_requirement_form.html
+++ b/templates/admission/general_education/includes/checklist/previous_experiences_admission_requirement_form.html
@@ -26,6 +26,9 @@
 
 <div
     id="previous-experiences-admission-requirement-container"
+    {% if with_swap_oob %}
+    hx-swap-oob="true"
+    {% endif %}
 >
   <form
       hx-post="{% url view.base_namespace|add:':past-experiences-admission-requirement' uuid=view.kwargs.uuid %}"
@@ -54,7 +57,7 @@
       </div>
     </div>
   </form>
-  {% if request.htmx %}
+  {% if request.htmx and not with_swap_oob %}
     {# Update the access condition in the header #}
     <span id="header-access-condition" hx-swap-oob="innerHTML">
       {% translate 'Not specified' context "admission-header" as not_specified %}

--- a/tests/views/general_education/checklist/test_past_experiences.py
+++ b/tests/views/general_education/checklist/test_past_experiences.py
@@ -25,6 +25,7 @@
 # ##############################################################################
 
 import datetime
+import json
 import uuid
 from unittest.mock import patch
 from uuid import UUID
@@ -169,6 +170,9 @@ class PastExperiencesStatusViewTestCase(SicPatchMixin):
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.today())
 
+        htmx_info = json.loads(response.headers['HX-Trigger'])
+        self.assertTrue(htmx_info.get('formValidation', {}).get('select_access_title_perm'))
+
     def test_change_the_checklist_status_to_success(self):
         self.client.force_login(user=self.sic_manager_user)
 
@@ -226,6 +230,9 @@ class PastExperiencesStatusViewTestCase(SicPatchMixin):
         self.assertEqual(self.general_admission.last_update_author, self.sic_manager_user.person)
         self.assertEqual(self.general_admission.modified_at, datetime.datetime.today())
 
+        htmx_info = json.loads(response.headers['HX-Trigger'])
+        self.assertFalse(htmx_info.get('formValidation', {}).get('select_access_title_perm'))
+
 
 @freezegun.freeze_time('2023-01-01')
 class PastExperiencesAdmissionRequirementViewTestCase(TestCase):
@@ -276,7 +283,7 @@ class PastExperiencesAdmissionRequirementViewTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_initialization_of_the_form_with_valid_initial_choices(self):
+    def test_initialization_of_the_form(self):
         self.client.force_login(user=self.sic_manager_user)
 
         response = self.client.post(self.url, **self.default_headers)
@@ -295,6 +302,9 @@ class PastExperiencesAdmissionRequirementViewTestCase(TestCase):
             (ConditionAcces.UNI_SNU_AUTRE.name, ConditionAcces.UNI_SNU_AUTRE.label),
         ]
         self.assertEqual(form.fields['admission_requirement'].choices, BLANK_CHOICE + bachelor_choices)
+        self.assertFalse(form.fields['admission_requirement'].disabled)
+        self.assertFalse(form.fields['admission_requirement_year'].disabled)
+        self.assertFalse(form.fields['with_prerequisite_courses'].disabled)
 
         self.assertEqual(
             recuperer_conditions_acces_par_formation(TrainingType.BACHELOR.name),
@@ -439,6 +449,19 @@ class PastExperiencesAdmissionRequirementViewTestCase(TestCase):
                 (ConditionAcces.PARCOURS.name, ConditionAcces.PARCOURS.label),
             ],
         )
+
+        self.general_admission.checklist['current']['parcours_anterieur']['statut'] = 'GEST_REUSSITE'
+        self.general_admission.save(update_fields=['checklist'])
+
+        response = self.client.get(self.url, **self.default_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        form = response.context['past_experiences_admission_requirement_form']
+
+        self.assertTrue(form.fields['admission_requirement'].disabled)
+        self.assertTrue(form.fields['admission_requirement_year'].disabled)
+        self.assertFalse(form.fields['with_prerequisite_courses'].disabled)
 
     @freezegun.freeze_time('2023-01-01', as_kwarg='frozen_time')
     def test_post_form_with_with_prerequisite_courses(self, frozen_time):
@@ -1089,20 +1112,43 @@ class PastExperiencesAccessTitleViewTestCase(TestCase):
         )
         self.url = resolve_url(self.url_name, uuid=self.general_admission.uuid)
 
-    def test_specify_an_experience_as_access_title_is_forbidden_with_fac_user_if_the_admission_is_in_sic_status(self):
+    def test_specify_an_experience_as_access_title_is_sometimes_forbidden_with_fac_user(self):
         self.client.force_login(user=self.fac_manager_user)
 
-        response = self.client.post(self.url, **self.default_headers)
+        # If the admission is in fac status
+        self.general_admission.status = ChoixStatutPropositionGenerale.CONFIRMEE.name
+        self.general_admission.save()
+
+        response = self.client.get(self.url, **self.default_headers)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_specify_an_experience_as_access_title_is_forbidden_with_sic_user_if_the_admission_is_in_fac_status(self):
+        # If the past experience checklist tab status is 'Sufficient'
+        self.general_admission.status = ChoixStatutPropositionGenerale.TRAITEMENT_FAC.name
+        self.general_admission.checklist['current']['parcours_anterieur']['statut'] = 'GEST_REUSSITE'
+        self.general_admission.save(update_fields=['checklist', 'status'])
+
+        response = self.client.get(self.url, **self.default_headers)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_specify_an_experience_as_access_title_is_sometimes_forbidden_with_sic_user(self):
+        self.client.force_login(user=self.sic_manager_user)
+
+        # If the admission is in fac status
         self.general_admission.status = ChoixStatutPropositionGenerale.TRAITEMENT_FAC.name
         self.general_admission.save()
 
-        self.client.force_login(user=self.sic_manager_user)
+        response = self.client.get(self.url, **self.default_headers)
 
-        response = self.client.post(self.url, **self.default_headers)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # If the past experience checklist tab status is 'Sufficient'
+        self.general_admission.status = ChoixStatutPropositionGenerale.CONFIRMEE.name
+        self.general_admission.checklist['current']['parcours_anterieur']['statut'] = 'GEST_REUSSITE'
+        self.general_admission.save(update_fields=['checklist', 'status'])
+
+        response = self.client.get(self.url, **self.default_headers)
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/views/doctorate/details/checklist/past_experiences.py
+++ b/views/doctorate/details/checklist/past_experiences.py
@@ -117,6 +117,13 @@ class PastExperiencesStatusView(
         super().__init__(*args, **kwargs)
         self.valid_operation = False
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['past_experiences_admission_requirement_form'] = DoctoratePastExperiencesAdmissionRequirementForm(
+            instance=self.admission,
+        )
+        return context
+
     def get_initial(self):
         return self.admission.checklist['current']['parcours_anterieur']['statut']
 
@@ -135,6 +142,12 @@ class PastExperiencesStatusView(
                 )
             )
             self.valid_operation = True
+            self.htmx_trigger_form_extra = {
+                'select_access_title_perm': self.request.user.has_perm(
+                    'admission.checklist_select_access_title',
+                    self.admission,
+                ),
+            }
         except MultipleBusinessExceptions:
             return super().form_invalid(form)
 

--- a/views/general_education/details/checklist.py
+++ b/views/general_education/details/checklist.py
@@ -1741,6 +1741,13 @@ class PastExperiencesStatusView(
         super().__init__(*args, **kwargs)
         self.valid_operation = False
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['past_experiences_admission_requirement_form'] = PastExperiencesAdmissionRequirementForm(
+            instance=self.admission,
+        )
+        return context
+
     def get_initial(self):
         return self.admission.checklist['current']['parcours_anterieur']['statut']
 
@@ -1759,6 +1766,12 @@ class PastExperiencesStatusView(
                 )
             )
             self.valid_operation = True
+            self.htmx_trigger_form_extra = {
+                'select_access_title_perm': self.request.user.has_perm(
+                    'admission.checklist_select_access_title',
+                    self.admission,
+                ),
+            }
         except MultipleBusinessExceptions:
             return super().form_invalid(form)
 


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1265 vers DEV