### PR TITLE
[hotfix/OS-1248 => DEV] Back-office: Parcours antérieur > Périodes à justifier > Les formations académiques et les activités non-académiques justifieront une période même lorsque des documents sont manquants

### DIFF
--- a/ddd/admission/doctorat/preparation/domain/validator/validator_by_business_action.py
+++ b/ddd/admission/doctorat/preparation/domain/validator/validator_by_business_action.py
@@ -342,7 +342,6 @@ class CurriculumPostSoumissionValidatorList(TwoStepsMultipleBusinessExceptionLis
     annee_diplome_etudes_secondaires: Optional[int]
     experiences_non_academiques: List[ExperienceNonAcademiqueDTO]
     experiences_academiques: List[ExperienceAcademiqueDTO]
-    experiences_academiques_incompletes: Dict[str, str]
     experiences_parcours_interne: List[ExperienceParcoursInterneDTO]
 
     def get_data_contract_validators(self) -> List[BusinessValidator]:
@@ -353,7 +352,7 @@ class CurriculumPostSoumissionValidatorList(TwoStepsMultipleBusinessExceptionLis
             ShouldAnneesCVRequisesCompletees(
                 annee_courante=self.annee_soumission,
                 experiences_academiques=self.experiences_academiques,
-                experiences_academiques_incompletes=self.experiences_academiques_incompletes,
+                experiences_academiques_incompletes={},
                 annee_derniere_inscription_ucl=None,
                 annee_diplome_etudes_secondaires=self.annee_diplome_etudes_secondaires,
                 experiences_non_academiques=self.experiences_non_academiques,

--- a/ddd/admission/doctorat/preparation/test/use_case/read/test_verifier_curriculum_apres_soumission_service.py
+++ b/ddd/admission/doctorat/preparation/test/use_case/read/test_verifier_curriculum_apres_soumission_service.py
@@ -369,10 +369,7 @@ class TestVerifierCurriculumApresSoumissionService(TestCase):
                 context.exception.exceptions,
                 [
                     'De Septembre 2010 à Février 2011',
-                    'De Septembre 2011 à Février 2012',
                     'De Septembre 2012 à Février 2013',
-                    'De Septembre 2013 à Février 2014',
-                    'De Septembre 2014 à Octobre 2014',
                 ],
             )
 

--- a/ddd/admission/domain/service/profil_candidat.py
+++ b/ddd/admission/domain/service/profil_candidat.py
@@ -258,16 +258,10 @@ class ProfilCandidat(interface.DomainService):
             else curriculum_dto
         )
 
-        experiences_academiques_incompletes = VerifierCurriculum.recuperer_experiences_academiques_incompletes(
-            experiences=curriculum.experiences_academiques,
-            annee_courante=annee_soumission,
-        )
-
         FormationGeneraleCurriculumPostSoumissionValidatorList(
             date_soumission=date_soumission,
             annee_soumission=annee_soumission,
             experiences_academiques=curriculum.experiences_academiques,
-            experiences_academiques_incompletes=experiences_academiques_incompletes,
             annee_diplome_etudes_secondaires=curriculum.annee_diplome_etudes_secondaires,
             experiences_non_academiques=curriculum.experiences_non_academiques,
             experiences_parcours_interne=experiences_parcours_interne,
@@ -303,16 +297,10 @@ class ProfilCandidat(interface.DomainService):
             else curriculum_dto
         )
 
-        experiences_academiques_incompletes = VerifierCurriculumDoctorat.recuperer_experiences_academiques_incompletes(
-            experiences=curriculum.experiences_academiques,
-            annee_courante=annee_soumission,
-        )
-
         CurriculumPostSoumissionValidatorList(
             date_soumission=date_soumission,
             annee_soumission=annee_soumission,
             experiences_academiques=curriculum.experiences_academiques,
-            experiences_academiques_incompletes=experiences_academiques_incompletes,
             annee_diplome_etudes_secondaires=curriculum.annee_diplome_etudes_secondaires,
             experiences_non_academiques=curriculum.experiences_non_academiques,
             experiences_parcours_interne=experiences_parcours_interne,

--- a/ddd/admission/formation_generale/domain/validator/validator_by_business_actions.py
+++ b/ddd/admission/formation_generale/domain/validator/validator_by_business_actions.py
@@ -152,7 +152,6 @@ class FormationGeneraleCurriculumPostSoumissionValidatorList(TwoStepsMultipleBus
     annee_diplome_etudes_secondaires: Optional[int]
     experiences_non_academiques: List[ExperienceNonAcademiqueDTO]
     experiences_academiques: List[ExperienceAcademiqueDTO]
-    experiences_academiques_incompletes: Dict[str, str]
     experiences_parcours_interne: List[ExperienceParcoursInterneDTO]
 
     def get_data_contract_validators(self) -> List[BusinessValidator]:
@@ -163,7 +162,7 @@ class FormationGeneraleCurriculumPostSoumissionValidatorList(TwoStepsMultipleBus
             ShouldAnneesCVRequisesCompletees(
                 annee_courante=self.annee_soumission,
                 experiences_academiques=self.experiences_academiques,
-                experiences_academiques_incompletes=self.experiences_academiques_incompletes,
+                experiences_academiques_incompletes={},
                 annee_derniere_inscription_ucl=None,
                 annee_diplome_etudes_secondaires=self.annee_diplome_etudes_secondaires,
                 experiences_non_academiques=self.experiences_non_academiques,

--- a/ddd/admission/formation_generale/test/use_case/read/test_verifier_curriculum_apres_soumission_service.py
+++ b/ddd/admission/formation_generale/test/use_case/read/test_verifier_curriculum_apres_soumission_service.py
@@ -367,10 +367,7 @@ class TestVerifierCurriculumApresSoumissionService(TestCase):
                 context.exception.exceptions,
                 [
                     'De Septembre 2010 à Février 2011',
-                    'De Septembre 2011 à Février 2012',
                     'De Septembre 2012 à Février 2013',
-                    'De Septembre 2013 à Février 2014',
-                    'De Septembre 2014 à Octobre 2014',
                 ],
             )
 

--- a/tests/utils/test_curriculum_checking.py
+++ b/tests/utils/test_curriculum_checking.py
@@ -213,10 +213,7 @@ class GetMissingCurriculumPeriodsTestCase(TestCase):
             result,
             [
                 'De Septembre 2010 à Février 2011',
-                'De Septembre 2011 à Février 2012',
                 'De Septembre 2012 à Février 2013',
-                'De Septembre 2013 à Février 2014',
-                'De Septembre 2014 à Décembre 2014',
             ],
         )
 


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1248 vers DEV