### PR TITLE
[hotfix/OS-1276 => MASTER] Front-office : confirmation/finalisation > Tardif > La période des demandes tardives devra débuter 31 jours avant la fin de la période concernée, au lieu de 30 jours

### DIFF
--- a/ddd/admission/formation_generale/domain/service/i_inscription_tardive.py
+++ b/ddd/admission/formation_generale/domain/service/i_inscription_tardive.py
@@ -36,7 +36,7 @@ class IInscriptionTardive(interface.DomainService):
         AcademicCalendarTypes.ADMISSION_POOL_HUE_UCL_PATHWAY_CHANGE,
         AcademicCalendarTypes.ADMISSION_POOL_UE5_BELGIAN,
     ]
-    SEUIL_JOURS_INSCRIPTION_TARDIVE = 30
+    SEUIL_JOURS_INSCRIPTION_TARDIVE = 31
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1276 vers MASTER