### PR TITLE
[hotfix/OS-1286 => DEV] Back-office : Choix de formation > Tooltip de l_icône d_inscription tardive : remplacer _choix_formation_ par _Inscription tardive_ (EN : Late enrollment)

### DIFF
--- a/views/general_education/details/checklist.py
+++ b/views/general_education/details/checklist.py
@@ -325,6 +325,7 @@ class CheckListDefaultContextMixin(LoadDossierViewMixin):
 
         if self.proposition.est_inscription_tardive:
             checklist_additional_icons['choix_formation'] = 'fa-regular fa-calendar-clock'
+            checklist_additional_icons_title['choix_formation'] = _('Late enrollment')
 
         candidate_admissions: List[DemandeRechercheDTO] = message_bus_instance.invoke(
             ListerToutesDemandesQuery(


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1286 vers DEV