### PR TITLE
[hotfix/OS-1287 => DEV] Back-office: Vues du parcours annualisé > Cases à cocher du titre d_accès > Tooltip au suvol des cases verrouillées (par l_état _Suffisant_ du parcours antérieur)

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1523,6 +1523,11 @@ msgstr ""
 msgid "Change the publication for this conference"
 msgstr ""
 
+msgid ""
+"Changes for the access title are not available when the state of the "
+"Previous experience is \"Sufficient\"."
+msgstr ""
+
 msgid "Checklist"
 msgstr ""
 

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -1672,6 +1672,13 @@ msgstr "Modifier la communication de ce séminaire"
 msgid "Change the publication for this conference"
 msgstr "Modifier la publication de cette conférence"
 
+msgid ""
+"Changes for the access title are not available when the state of the "
+"Previous experience is \"Sufficient\"."
+msgstr ""
+"Les changements de titre d’accès ne sont pas disponibles lorsque le parcours "
+"antérieur est à l'état \"Suffisant\"."
+
 msgid "Checklist"
 msgstr "Checklist"
 

--- a/templates/admission/doctorate/checklist.html
+++ b/templates/admission/doctorate/checklist.html
@@ -897,7 +897,9 @@
           $('#parcours_anterieur').on('formValidation', '.checklist-state-button', function(event) {
               {# The access titles can be updated only if the fac decision status is not sufficient. #}
               if (event.originalEvent.detail.select_access_title_perm !== undefined) {
-                $('input[name="access-title"]').prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+                const access_titles_checkboxes = $('input[name="access-title"]');
+                access_titles_checkboxes.prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+                access_titles_checkboxes.prop('title', event.originalEvent.detail.select_access_title_tooltip || '');
               }
           });
 

--- a/templates/admission/general_education/checklist.html
+++ b/templates/admission/general_education/checklist.html
@@ -994,7 +994,9 @@
           $('#parcours_anterieur').on('formValidation', '.checklist-state-button', function(event) {
               {# The access titles can be updated only if the fac decision status is not sufficient. #}
               if (event.originalEvent.detail.select_access_title_perm !== undefined) {
-                $('input[name="access-title"]').prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+                const access_titles_checkboxes = $('input[name="access-title"]');
+                access_titles_checkboxes.prop('disabled', event.originalEvent.detail.select_access_title_perm === false);
+                access_titles_checkboxes.prop('title', event.originalEvent.detail.select_access_title_tooltip || '');
               }
           });
 

--- a/templates/admission/general_education/includes/checklist/parcours_row_access_title.html
+++ b/templates/admission/general_education/includes/checklist/parcours_row_access_title.html
@@ -37,6 +37,7 @@
           checked="checked"
           {% endif %}
           {% if can_choose_access_title is False %}disabled{% endif %}
+          {% if can_choose_access_title_tooltip %}title="{{ can_choose_access_title_tooltip }}"{% endif %}
       />
     </label>
   </div>

--- a/templatetags/admission.py
+++ b/templatetags/admission.py
@@ -1259,6 +1259,7 @@ def access_title_checkbox(context, experience_uuid, experience_type, current_yea
             'checked': access_title.selectionne,
             'experience_uuid': experience_uuid,
             'can_choose_access_title': context['can_choose_access_title'],
+            'can_choose_access_title_tooltip': context.get('can_choose_access_title_tooltip'),
         }
 
 

--- a/tests/views/doctorate/checklist/test_past_experiences.py
+++ b/tests/views/doctorate/checklist/test_past_experiences.py
@@ -210,6 +210,13 @@ class PastExperiencesStatusViewTestCase(SicPatchMixin):
         self.assertIn(gettext('Your data have been saved.'), messages)
         htmx_info = json.loads(response.headers['HX-Trigger'])
         self.assertFalse(htmx_info.get('formValidation', {}).get('select_access_title_perm'))
+        self.assertEqual(
+            htmx_info.get('formValidation', {}).get('select_access_title_tooltip'),
+            gettext(
+                'Changes for the access title are not available when the state of the Previous experience '
+                'is "Sufficient".'
+            ),
+        )
 
         # Check admission
         self.admission.refresh_from_db()

--- a/tests/views/general_education/checklist/test_past_experiences.py
+++ b/tests/views/general_education/checklist/test_past_experiences.py
@@ -232,6 +232,13 @@ class PastExperiencesStatusViewTestCase(SicPatchMixin):
 
         htmx_info = json.loads(response.headers['HX-Trigger'])
         self.assertFalse(htmx_info.get('formValidation', {}).get('select_access_title_perm'))
+        self.assertEqual(
+            htmx_info.get('formValidation', {}).get('select_access_title_tooltip'),
+            gettext(
+                'Changes for the access title are not available when the state of the Previous experience '
+                'is "Sufficient".'
+            ),
+        )
 
 
 @freezegun.freeze_time('2023-01-01')

--- a/views/doctorate/details/checklist/base.py
+++ b/views/doctorate/details/checklist/base.py
@@ -545,6 +545,14 @@ class ChecklistView(
                 }
             )
             context['can_choose_access_title'] = can_change_access_title
+            context['can_choose_access_title_tooltip'] = (
+                _(
+                    'Changes for the access title are not available when the state of the Previous experience '
+                    'is "Sufficient".'
+                )
+                if context.get('past_experiences_are_sufficient')
+                else ''
+            )
 
             context['digit_ticket'] = message_bus_instance.invoke(
                 GetStatutTicketPersonneQuery(global_id=self.proposition.matricule_candidat)

--- a/views/doctorate/details/checklist/past_experiences.py
+++ b/views/doctorate/details/checklist/past_experiences.py
@@ -28,7 +28,7 @@ from typing import Dict, Optional
 from django.forms import Form
 from django.shortcuts import resolve_url
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, gettext
 from django.views.generic import FormView
 from osis_comment.models import CommentEntry
 from osis_history.models import HistoryEntry
@@ -45,6 +45,7 @@ from admission.ddd.admission.doctorat.preparation.commands import (
     ModifierStatutChecklistExperienceParcoursAnterieurCommand,
     ModifierAuthentificationExperienceParcoursAnterieurCommand,
 )
+from admission.ddd.admission.doctorat.preparation.domain.model.enums.checklist import ChoixStatutChecklist
 from admission.ddd.admission.domain.model.enums.condition_acces import TypeTitreAccesSelectionnable
 from admission.ddd.admission.domain.validator.exceptions import ExperienceNonTrouveeException
 from admission.ddd.admission.dtos.resume import (
@@ -148,6 +149,14 @@ class PastExperiencesStatusView(
                     self.admission,
                 ),
             }
+            if (
+                self.admission.checklist['current']['parcours_anterieur']['statut']
+                == ChoixStatutChecklist.GEST_REUSSITE.name
+            ):
+                self.htmx_trigger_form_extra['select_access_title_tooltip'] = gettext(
+                    'Changes for the access title are not available when the state of the Previous experience '
+                    'is "Sufficient".'
+                )
         except MultipleBusinessExceptions:
             return super().form_invalid(form)
 

--- a/views/general_education/details/checklist.py
+++ b/views/general_education/details/checklist.py
@@ -39,7 +39,7 @@ from django.urls import reverse
 from django.utils import translation, timezone
 from django.utils.formats import date_format
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _, ngettext, pgettext, override
+from django.utils.translation import gettext_lazy as _, ngettext, pgettext, override, gettext
 from django.views.generic import TemplateView, FormView
 from django.views.generic.base import RedirectView, View
 from django_htmx.http import HttpResponseClientRefresh
@@ -1772,6 +1772,14 @@ class PastExperiencesStatusView(
                     self.admission,
                 ),
             }
+            if (
+                self.admission.checklist['current']['parcours_anterieur']['statut']
+                == ChoixStatutChecklist.GEST_REUSSITE.name
+            ):
+                self.htmx_trigger_form_extra['select_access_title_tooltip'] = gettext(
+                    'Changes for the access title are not available when the state of the Previous experience '
+                    'is "Sufficient".'
+                )
         except MultipleBusinessExceptions:
             return super().form_invalid(form)
 
@@ -3065,6 +3073,14 @@ class ChecklistView(
                 }
             )
             context['can_choose_access_title'] = can_change_access_title
+            context['can_choose_access_title_tooltip'] = (
+                _(
+                    'Changes for the access title are not available when the state of the Previous experience '
+                    'is "Sufficient".'
+                )
+                if context.get('past_experiences_are_sufficient')
+                else ''
+            )
 
             context['digit_ticket'] = message_bus_instance.invoke(
                 GetStatutTicketPersonneQuery(global_id=self.proposition.matricule_candidat)


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1287 vers DEV