### PR TITLE
[hotfix/OS-1290 => DEV] Back-office: Spécificités > Modification d_inscription : Lorsqu_un candidat ne déclare pas être en modification, puis que SIC corrige pour qu_il le soit, la demande est pour l_instant en {tardive + modification} 

### DIFF
--- a/ddd/admission/formation_generale/domain/model/proposition.py
+++ b/ddd/admission/formation_generale/domain/model/proposition.py
@@ -798,6 +798,8 @@ class Proposition(interface.RootEntity):
         self.attestation_inscription_reguliere = attestation_inscription_reguliere
         self.est_modification_inscription_externe = est_modification_inscription_externe
         self.formulaire_modification_inscription = formulaire_modification_inscription
+        if self.est_modification_inscription_externe:
+            self.est_inscription_tardive = False
 
     def specifier_financabilite_resultat_calcul(
         self,

--- a/tests/views/common/form_tabs/test_specific_questions.py
+++ b/tests/views/common/form_tabs/test_specific_questions.py
@@ -291,6 +291,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
             status=ChoixStatutPropositionGenerale.CONFIRMEE.name,
             determined_academic_year=self.academic_years[1],
             is_non_resident=False,
+            late_enrollment=True,
         )
 
         url = resolve_url('admission:general-education:update:specific-questions', uuid=general_admission.uuid)
@@ -321,6 +322,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             general_admission.requested_documents,
         )
+        self.assertTrue(general_admission.late_enrollment)
 
         # With data
         response = self.client.post(
@@ -354,6 +356,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
         self.assertEqual(general_admission.regular_registration_proof, [])
         self.assertEqual(general_admission.is_external_modification, None)
         self.assertEqual(general_admission.registration_change_form, [])
+        self.assertTrue(general_admission.late_enrollment)
 
         # With diplomatic post
         general_admission.candidate.country_of_citizenship = self.ca_country
@@ -388,6 +391,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
             status=ChoixStatutPropositionGenerale.CONFIRMEE.name,
             determined_academic_year=self.academic_years[1],
             is_non_resident=False,
+            late_enrollment=True,
         )
 
         url = resolve_url('admission:general-education:update:specific-questions', uuid=general_admission.uuid)
@@ -427,6 +431,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
             f'{OngletsDemande.IDENTIFICATION.name}.PHOTO_IDENTITE',
             general_admission.requested_documents,
         )
+        self.assertTrue(general_admission.late_enrollment)
 
         # With data -> modification
         response = self.client.post(
@@ -456,6 +461,7 @@ class GeneralSpecificQuestionsFormViewTestCase(TestCase):
             general_admission.registration_change_form,
             [self.file_uuids['formulaire_modification_inscription']],
         )
+        self.assertFalse(general_admission.late_enrollment)
 
         # With data -> modification & reorientation
         response = self.client.post(


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1290 vers DEV