### PR TITLE
[hotfix/OS-1589 => QA] Back-office: Vues du parcours antérieur > Examens (ingé, médé, 1erC) : Case à cocher _titre d_accès_ présente dans 100% des cas & Intégration des examens à la checklist & Etat _Validé_ dispo slmt lorsque fichier et année présents

### DIFF
--- a/infrastructure/admission/shared_kernel/repository/titre_acces_selectionnable.py
+++ b/infrastructure/admission/shared_kernel/repository/titre_acces_selectionnable.py
@@ -33,19 +33,23 @@ from django.utils.translation import get_language, gettext
 from admission.ddd.admission.shared_kernel.domain.model.enums.condition_acces import (
     TypeTitreAccesSelectionnable,
 )
-from admission.ddd.admission.shared_kernel.domain.model.proposition import PropositionIdentity
+from admission.ddd.admission.shared_kernel.domain.model.proposition import (
+    PropositionIdentity,
+)
 from admission.ddd.admission.shared_kernel.domain.model.titre_acces_selectionnable import (
     TitreAccesSelectionnable,
     TitreAccesSelectionnableIdentity,
-)
-from admission.ddd.admission.shared_kernel.repository.i_titre_acces_selectionnable import (
-    ITitreAccesSelectionnableRepository,
 )
 from admission.ddd.admission.shared_kernel.domain.validator.exceptions import (
     ExperienceNonTrouveeException,
     PropositionNonTrouveeException,
 )
-from admission.ddd.admission.shared_kernel.enums.emplacement_document import OngletsDemande
+from admission.ddd.admission.shared_kernel.enums.emplacement_document import (
+    OngletsDemande,
+)
+from admission.ddd.admission.shared_kernel.repository.i_titre_acces_selectionnable import (
+    ITitreAccesSelectionnableRepository,
+)
 from admission.models.base import (
     AdmissionEducationalValuatedExperiences,
     AdmissionProfessionalValuatedExperiences,
@@ -225,11 +229,7 @@ class TitreAccesSelectionnableRepository(ITitreAccesSelectionnableRepository):
             .select_related('year')
             .first()
         )
-        if (
-            exam is not None
-            and exam.year is not None
-            and (not seulement_selectionnes or admission.is_exam_access_title)
-        ):
+        if exam is not None and (not seulement_selectionnes or admission.is_exam_access_title):
             access_titles.append(
                 TitreAccesSelectionnable(
                     entity_id=TitreAccesSelectionnableIdentity(
@@ -238,7 +238,7 @@ class TitreAccesSelectionnableRepository(ITitreAccesSelectionnableRepository):
                         type_titre=TypeTitreAccesSelectionnable.EXAMENS,
                     ),
                     selectionne=bool(admission.is_exam_access_title),
-                    annee=exam.year.year,
+                    annee=exam.year.year if exam.year else None,
                     pays_iso_code='',
                     nom='{title} ({year})'.format(
                         title=(
@@ -246,7 +246,7 @@ class TitreAccesSelectionnableRepository(ITitreAccesSelectionnableRepository):
                             if has_default_language
                             else exam.education_group_year_exam.title_en
                         ),
-                        year=format_academic_year(exam.year.year),
+                        year=format_academic_year(exam.year.year) if exam.year else '',
                     ),
                 ),
             )

--- a/templates/admission/exports/recap/includes/exams.html
+++ b/templates/admission/exports/recap/includes/exams.html
@@ -23,27 +23,24 @@
   * see http://www.gnu.org/licenses/.
 {% endcomment %}
 {% panel _('Exams') edit_link_button=edit_link_button %}
+  {% if LANGUAGE_CODE == 'fr-be' %}
+    {% firstof examen.titre education_group_year_exam.title_fr "Examen" as titre_examen %}
+  {% else %}
+    {% firstof examen.titre education_group_year_exam.title_en "Exam" as titre_examen %}
+  {% endif %}
+
   {% if hide_files %}
-    {% if LANGUAGE_CODE == 'fr-be' %}
-      {% if examen.attestation %}
-        {% field_data education_group_year_exam.title_fr _("Specified") %}
-      {% else %}
-        {% field_data education_group_year_exam.title_fr _("Not specified") %}
-      {% endif %}
+
+    {% if examen.attestation %}
+      {% field_data titre_examen _("Specified") %}
     {% else %}
-      {% if examen.attestation %}
-        {% field_data education_group_year_exam.title_en _("Specified") %}
-      {% else %}
-        {% field_data education_group_year_exam.title_en _("Not specified") %}
-      {% endif %}
+      {% field_data titre_examen _("Not specified") %}
     {% endif %}
 
   {% else %}
-    {% if LANGUAGE_CODE == 'fr-be' %}
-      {% field_data education_group_year_exam.title_fr examen.attestation %}
-    {% else %}
-      {% field_data education_group_year_exam.title_en examen.attestation %}
-    {% endif %}
+
+    {% field_data titre_examen examen.attestation %}
+
   {% endif %}
 
   {% if examen.annee %}

--- a/templatetags/admission.py
+++ b/templatetags/admission.py
@@ -64,26 +64,6 @@ from admission.ddd.admission.doctorat.preparation.domain.model.statut_checklist 
     INDEX_ONGLETS_CHECKLIST as INDEX_ONGLETS_CHECKLIST_DOCTORALE,
 )
 from admission.ddd.admission.doctorat.validation.domain.model.enums import ChoixSexe
-from admission.ddd.admission.shared_kernel.domain.model.enums.authentification import (
-    EtatAuthentificationParcours,
-)
-from admission.ddd.admission.shared_kernel.dtos import (
-    CoordonneesDTO,
-    EtudesSecondairesAdmissionDTO,
-    IdentificationDTO,
-)
-from admission.ddd.admission.shared_kernel.dtos.emplacement_document import EmplacementDocumentDTO
-from admission.ddd.admission.shared_kernel.dtos.liste import DemandeRechercheDTO
-from admission.ddd.admission.shared_kernel.dtos.profil_candidat import ProfilCandidatDTO
-from admission.ddd.admission.shared_kernel.dtos.question_specifique import QuestionSpecifiqueDTO
-from admission.ddd.admission.shared_kernel.dtos.resume import ResumePropositionDTO
-from admission.ddd.admission.shared_kernel.dtos.titre_acces_selectionnable import (
-    TitreAccesSelectionnableDTO,
-)
-from admission.ddd.admission.shared_kernel.enums import Onglets, TypeItemFormulaire
-from admission.ddd.admission.shared_kernel.enums.emplacement_document import (
-    StatutReclamationEmplacementDocument,
-)
 from admission.ddd.admission.formation_continue.domain.model.enums import (
     ChoixMoyensDecouverteFormation,
     ChoixStatutPropositionContinue,
@@ -108,7 +88,33 @@ from admission.ddd.admission.formation_generale.dtos.proposition import (
 from admission.ddd.admission.formation_generale.dtos.proposition import (
     PropositionGestionnaireDTO,
 )
-from admission.ddd.admission.shared_kernel.repository.i_proposition import formater_reference
+from admission.ddd.admission.shared_kernel.domain.model.enums.authentification import (
+    EtatAuthentificationParcours,
+)
+from admission.ddd.admission.shared_kernel.dtos import (
+    CoordonneesDTO,
+    EtudesSecondairesAdmissionDTO,
+    IdentificationDTO,
+)
+from admission.ddd.admission.shared_kernel.dtos.emplacement_document import (
+    EmplacementDocumentDTO,
+)
+from admission.ddd.admission.shared_kernel.dtos.liste import DemandeRechercheDTO
+from admission.ddd.admission.shared_kernel.dtos.profil_candidat import ProfilCandidatDTO
+from admission.ddd.admission.shared_kernel.dtos.question_specifique import (
+    QuestionSpecifiqueDTO,
+)
+from admission.ddd.admission.shared_kernel.dtos.resume import ResumePropositionDTO
+from admission.ddd.admission.shared_kernel.dtos.titre_acces_selectionnable import (
+    TitreAccesSelectionnableDTO,
+)
+from admission.ddd.admission.shared_kernel.enums import Onglets, TypeItemFormulaire
+from admission.ddd.admission.shared_kernel.enums.emplacement_document import (
+    StatutReclamationEmplacementDocument,
+)
+from admission.ddd.admission.shared_kernel.repository.i_proposition import (
+    formater_reference,
+)
 from admission.exports.admission_recap.section import (
     get_educational_experience_context,
     get_non_educational_experience_context,
@@ -1261,6 +1267,10 @@ def experience_details_template(
                 specific_questions[Onglets.ETUDES_SECONDAIRES.name],
             )
         )
+
+    elif experience.__class__ == ExamenDTO:
+        res_context['custom_base_template'] = 'admission/exports/recap/includes/exams.html'
+        res_context['examen'] = experience
 
     return res_context
 

--- a/tests/infrastructure/admission/domain/service/test_profil_candidat.py
+++ b/tests/infrastructure/admission/domain/service/test_profil_candidat.py
@@ -40,6 +40,8 @@ from admission.tests.factories.secondary_studies import (
     HighSchoolDiplomaAlternativeFactory,
 )
 from base.tests.factories.person import PersonFactory
+from osis_profile.models.enums.exam import ExamTypes
+from osis_profile.tests.factories.exam import ExamFactory
 
 
 class ValorisationEtudesSecondairesTestCase(TestCase):
@@ -309,3 +311,13 @@ class RecupererUuidsExperiencesCurriculumValoriseesParAdmissionTestCase(TestCase
             uuids,
             [str(other_educational_experience.uuid), str(other_professional_experience.uuid)],
         )
+
+    def retrieve_valuated_exam_requis(self):
+        ExamFactory(person=self.admission.candidate, education_group_year_exam__education_group_year=self.admission.training)
+        uuids = ProfilCandidatTranslator.get_uuids_experiences_curriculum_valorisees_par_admission(self.admission.uuid)
+        self.assertEqual(uuids, ['EXAMS'])
+
+    def retrieve_valuated_alternative_secondary_study_exam(self):
+        ExamFactory(person=self.admission.candidate, type=ExamTypes.PREMIER_CYCLE.name)
+        uuids = ProfilCandidatTranslator.get_uuids_experiences_curriculum_valorisees_par_admission(self.admission.uuid)
+        self.assertEqual(uuids, ['ETUDES_SECONDAIRES'])

--- a/views/general_education/details/checklist.py
+++ b/views/general_education/details/checklist.py
@@ -55,10 +55,6 @@ from osis_mail_template.models import MailTemplate
 
 from admission.constants import COMMENT_TAG_FAC, COMMENT_TAG_SIC
 from admission.ddd import MAIL_VERIFICATEUR_CURSUS, MONTANT_FRAIS_DOSSIER
-from admission.ddd.admission.shared_kernel.commands import (
-    ListerToutesDemandesQuery,
-    RechercherParcoursAnterieurQuery, RecupererInformationsDestinataireQuery,
-)
 from admission.ddd.admission.doctorat.preparation.domain.validator.exceptions import (
     AnneesCurriculumNonSpecifieesException,
     ExperiencesAcademiquesNonCompleteesException,
@@ -67,33 +63,6 @@ from admission.ddd.admission.doctorat.preparation.dtos.curriculum import (
     message_candidat_avec_pae_avant_2015,
 )
 from admission.ddd.admission.doctorat.validation.domain.model.enums import ChoixGenre
-from admission.ddd.admission.shared_kernel.domain.validator.exceptions import (
-    ExperienceNonTrouveeException,
-    InformationsDestinatairePasTrouvee,
-)
-from admission.ddd.admission.shared_kernel.domain.model.enums.authentification import (
-    EtatAuthentificationParcours,
-)
-from admission.ddd.admission.shared_kernel.dtos.liste import DemandeRechercheDTO
-from admission.ddd.admission.shared_kernel.dtos.question_specifique import QuestionSpecifiqueDTO
-from admission.ddd.admission.shared_kernel.dtos.resume import (
-    ResumeCandidatDTO,
-    ResumeEtEmplacementsDocumentsPropositionDTO,
-    ResumePropositionDTO,
-)
-from admission.ddd.admission.shared_kernel.enums import Onglets, TypeItemFormulaire
-from admission.ddd.admission.shared_kernel.enums.emplacement_document import (
-    DocumentsAssimilation,
-    DocumentsEtudesSecondaires,
-    OngletsDemande,
-    StatutReclamationEmplacementDocument,
-)
-from admission.ddd.admission.shared_kernel.enums.statut import (
-    STATUTS_TOUTE_PROPOSITION_AUTORISEE,
-    STATUTS_TOUTE_PROPOSITION_SOUMISE,
-    STATUTS_TOUTE_PROPOSITION_SOUMISE_HORS_FRAIS_DOSSIER_OU_ANNULEE,
-)
-from admission.ddd.admission.shared_kernel.enums.type_demande import TypeDemande
 from admission.ddd.admission.formation_generale.commands import (
     ApprouverAdmissionParSicCommand,
     ApprouverInscriptionParSicCommand,
@@ -160,6 +129,40 @@ from admission.ddd.admission.formation_generale.domain.validator.exceptions impo
 from admission.ddd.admission.formation_generale.dtos.proposition import (
     PropositionGestionnaireDTO,
 )
+from admission.ddd.admission.shared_kernel.commands import (
+    ListerToutesDemandesQuery,
+    RechercherParcoursAnterieurQuery,
+    RecupererInformationsDestinataireQuery,
+)
+from admission.ddd.admission.shared_kernel.domain.model.enums.authentification import (
+    EtatAuthentificationParcours,
+)
+from admission.ddd.admission.shared_kernel.domain.validator.exceptions import (
+    ExperienceNonTrouveeException,
+    InformationsDestinatairePasTrouvee,
+)
+from admission.ddd.admission.shared_kernel.dtos.liste import DemandeRechercheDTO
+from admission.ddd.admission.shared_kernel.dtos.question_specifique import (
+    QuestionSpecifiqueDTO,
+)
+from admission.ddd.admission.shared_kernel.dtos.resume import (
+    ResumeCandidatDTO,
+    ResumeEtEmplacementsDocumentsPropositionDTO,
+    ResumePropositionDTO,
+)
+from admission.ddd.admission.shared_kernel.enums import Onglets, TypeItemFormulaire
+from admission.ddd.admission.shared_kernel.enums.emplacement_document import (
+    DocumentsAssimilation,
+    DocumentsEtudesSecondaires,
+    OngletsDemande,
+    StatutReclamationEmplacementDocument,
+)
+from admission.ddd.admission.shared_kernel.enums.statut import (
+    STATUTS_TOUTE_PROPOSITION_AUTORISEE,
+    STATUTS_TOUTE_PROPOSITION_SOUMISE,
+    STATUTS_TOUTE_PROPOSITION_SOUMISE_HORS_FRAIS_DOSSIER_OU_ANNULEE,
+)
+from admission.ddd.admission.shared_kernel.enums.type_demande import TypeDemande
 from admission.exports.admission_recap.section import get_dynamic_questions_by_tab
 from admission.forms import disable_unavailable_forms
 from admission.forms.admission.checklist import (
@@ -379,13 +382,17 @@ class CheckListDefaultContextMixin(LoadDossierViewMixin):
 
     @cached_property
     def incomplete_curriculum_experiences(self):
-        return {
+        experiences = {
             str(experience.uuid)
             for experience in self.proposition_resume.resume.curriculum.experiences_academiques
             if experience.champs_credits_bloc_1_et_complements_non_remplis(
                 self.proposition_resume.resume.proposition.formation.grade_academique,
             )
         }
+        examen = self.proposition_resume.resume.examens
+        if examen.requis and (not examen.attestation or not examen.annee):
+            experiences.add(OngletsDemande.EXAMS.name)
+        return experiences
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -3522,4 +3529,6 @@ class ChecklistView(
         for experience_non_academique in resume.curriculum.experiences_non_academiques:
             experiences[str(experience_non_academique.uuid)] = experience_non_academique
         experiences[OngletsDemande.ETUDES_SECONDAIRES.name] = resume.etudes_secondaires
+        if resume.examens.requis:
+            experiences[OngletsDemande.EXAMS.name] = resume.examens
         return experiences


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1589 vers QA